### PR TITLE
[CYP-97] Fix for bug in zipping directory

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -12,6 +12,16 @@ module.exports = function run(args) {
   return runCypress(args);
 }
 
+function deleteZip() {
+  fs.unlink(config.fileName, function (err) {
+    if(err) {
+      logger.log(Constants.userMessages.ZIP_DELETE_FAILED);
+    } else {
+      logger.log(Constants.userMessages.ZIP_DELETED);
+    }            
+  });
+}
+
 function runCypress(args) {
   let bsConfigPath = process.cwd() + args.cf;
   logger.log(`Reading config from ${args.cf}`);
@@ -30,25 +40,19 @@ function runCypress(args) {
         }).catch(function (err) {
           // Build creation failed
           logger.error(Constants.userMessages.BUILD_FAILED)
-        }).finally(function() {
-          // Delete zip file from local storage
-          fs.unlink(config.fileName, function (err) {
-            if(err) {
-              logger.log(Constants.userMessages.ZIP_DELETE_FAILED);
-            } else {
-              logger.log(Constants.userMessages.ZIP_DELETED);
-            }            
-          });
         });
       }).catch(function (err) {
         // Zip Upload failed
         logger.error(err)
         logger.error(Constants.userMessages.ZIP_UPLOAD_FAILED)
+      }).finally(function (params) {
+        deleteZip();
       });
     }).catch(function (err) {
       // Zipping failed
       logger.error(err)
       logger.error(Constants.userMessages.FAILED_TO_ZIP)
+      deleteZip();
     });
   }).catch(function (err) {
     // browerstack.json is not valid

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -45,7 +45,7 @@ function runCypress(args) {
         // Zip Upload failed
         logger.error(err)
         logger.error(Constants.userMessages.ZIP_UPLOAD_FAILED)
-      }).finally(function (params) {
+      }).finally(function () {
         deleteZip();
       });
     }).catch(function (err) {

--- a/bin/helpers/archiver.js
+++ b/bin/helpers/archiver.js
@@ -35,7 +35,8 @@ const archiveSpecs = (runSettings, filePath) => {
 
     archive.pipe(output);
 
-    archive.directory(cypressFolderPath, false);
+    let filesToIgnore = [ '*.zip', '*.mp4', '*.png', '*.jpeg', '^.' ]
+    archive.glob('**/*', { ignore: filesToIgnore, cwd:  cypressFolderPath });
 
     archive.finalize();
   });

--- a/bin/helpers/archiver.js
+++ b/bin/helpers/archiver.js
@@ -35,8 +35,10 @@ const archiveSpecs = (runSettings, filePath) => {
 
     archive.pipe(output);
 
-    let filesToIgnore = [ '*.zip', '*.mp4', '*.png', '*.jpeg', '^.' ]
-    archive.glob('**/*', { ignore: filesToIgnore, cwd:  cypressFolderPath });
+    let allowedFileTypes = [ 'js', 'json', 'txt', 'ts' ]
+    allowedFileTypes.forEach(fileType => {
+      archive.glob(`**/*.${fileType}`, { cwd:  cypressFolderPath, matchBase: true });
+    });
 
     archive.finalize();
   });

--- a/bin/helpers/archiver.js
+++ b/bin/helpers/archiver.js
@@ -37,7 +37,7 @@ const archiveSpecs = (runSettings, filePath) => {
 
     let allowedFileTypes = [ 'js', 'json', 'txt', 'ts' ]
     allowedFileTypes.forEach(fileType => {
-      archive.glob(`**/*.${fileType}`, { cwd:  cypressFolderPath, matchBase: true });
+      archive.glob(`**/*.${fileType}`, { cwd: cypressFolderPath, matchBase: true, ignore: 'node_modules/**' });
     });
 
     archive.finalize();

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -70,47 +70,8 @@ const validate = (bsConfig) => {
 
     if(!bsConfig.run_settings.cypress_proj_dir) reject(Constants.validationMessages.EMPTY_SPEC_FILES);
 
-    if(invalidFiles(bsConfig.run_settings.cypress_proj_dir)) reject(Constants.validationMessages.INVALID_EXTENSION);
-
     resolve(Constants.validationMessages.VALIDATED);
   });
-}
-
-const invalidFiles = (testFolder)=> {
-  var options = {
-    dot: true
-  }
-  files  = glob.sync(testFolder + "/**/*", options)
-  var invalidFiles = []
-  files.forEach(file => {
-    if(isHiddenPath(file) || invalidExtension(file)){
-      invalidFiles.push(file)
-    }
-  });
-
-  if(invalidFiles.length > 0) {
-    logger.log("These files are not valid: " + invalidFiles.toString())
-    return true
-  } else {
-    return false
-  }
-}
-
-var isHiddenPath = (path) => {
-  return (/(^|\/)\.[^\/\.]/g).test(path);
-};
-
-var invalidExtension = (file) => {
-  let ext = file.split('.').pop();
-  if (isFile(file) && !["js", "json", "txt"].includes(ext)) {
-    return true;
-  }
-
-  return false;
-}
-
-var isFile = (path) => {
-  return path.split('/').pop().indexOf('.') > -1;
 }
 
 module.exports = {


### PR DESCRIPTION
This PR fixes
1. Circular zipping issue when `browserstack.js` is in the same folder as `cypress.json`. I used `directory()` before which does not allow filtering, now using glob to select only allowed file extensions.
2. Whitelisting of the allowed file extension and adds the node_modules folder to ignore list
3. Deleting zip file in case of upload failure or zipping failure
4. Remove validation of file extension before zipping as it is handled during the zip creation now.