### PR TITLE
run command bug fix for missing browserstack.json

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -7,6 +7,7 @@ var config = require('../helpers/config');
 var capabilityHelper = require("../helpers/capabilityHelper");
 var fs = require('fs');
 const Constants = require('../helpers/constants');
+const fileHelpers = require('../helpers/fileHelpers');
 
 module.exports = function run(args) {
   return runCypress(args);
@@ -18,45 +19,51 @@ function deleteZip() {
       logger.log(Constants.userMessages.ZIP_DELETE_FAILED);
     } else {
       logger.log(Constants.userMessages.ZIP_DELETED);
-    }            
+    }
   });
 }
 
 function runCypress(args) {
   let bsConfigPath = process.cwd() + args.cf;
   logger.log(`Reading config from ${args.cf}`);
-  var bsConfig = require(bsConfigPath);
+  fileHelpers.fileExists(bsConfigPath, (configExists) => {
+    if (configExists) {
+      var bsConfig = require(bsConfigPath);
 
-  // Validate browserstack.json
-  capabilityHelper.validate(bsConfig).then(function (validated) {
-    logger.log(validated);
-    // Archive the spec files
-    archiver.archive(bsConfig.run_settings, config.fileName).then(function (data) {
-      // Uploaded zip file
-      zipUploader.zipUpload(bsConfig, config.fileName).then(function (zip) {
-        // Create build
-        build.createBuild(bsConfig, zip).then(function (data) {
-          return;
+      // Validate browserstack.json
+      capabilityHelper.validate(bsConfig).then(function (validated) {
+        logger.log(validated);
+        // Archive the spec files
+        archiver.archive(bsConfig.run_settings, config.fileName).then(function (data) {
+          // Uploaded zip file
+          zipUploader.zipUpload(bsConfig, config.fileName).then(function (zip) {
+            // Create build
+            build.createBuild(bsConfig, zip).then(function (data) {
+              return;
+            }).catch(function (err) {
+              // Build creation failed
+              logger.error(Constants.userMessages.BUILD_FAILED)
+            });
+          }).catch(function (err) {
+            // Zip Upload failed
+            logger.error(err)
+            logger.error(Constants.userMessages.ZIP_UPLOAD_FAILED)
+          }).finally(function () {
+            deleteZip();
+          });
         }).catch(function (err) {
-          // Build creation failed
-          logger.error(Constants.userMessages.BUILD_FAILED)
+          // Zipping failed
+          logger.error(err)
+          logger.error(Constants.userMessages.FAILED_TO_ZIP)
+          deleteZip();
         });
       }).catch(function (err) {
-        // Zip Upload failed
+        // browerstack.json is not valid
         logger.error(err)
-        logger.error(Constants.userMessages.ZIP_UPLOAD_FAILED)
-      }).finally(function () {
-        deleteZip();
+        logger.error(Constants.validationMessages.NOT_VALID)
       });
-    }).catch(function (err) {
-      // Zipping failed
-      logger.error(err)
-      logger.error(Constants.userMessages.FAILED_TO_ZIP)
-      deleteZip();
-    });
-  }).catch(function (err) {
-    // browerstack.json is not valid
-    logger.error(err)
-    logger.error(Constants.validationMessages.NOT_VALID)
+    } else {
+      logger.error('Could not find browserstack.json, you can create it by running `browserstack-cypress init`');
+    }
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If a user runs the `browserstack-cypress run` command without specifying a correct path to browserstack.json(default is the current dir), it fails with an exception.

This PR fixes the issue by validating if the file exists, and prints an error message in case it doesn't.