### PR TITLE
update keys in browserstack.json

### DIFF
--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -35,14 +35,14 @@ const caps = (bsConfig, zip) => {
 
     // Local Identifier
     obj.localIdentifier = null;
-    if (obj.local === true && bsConfig.connection_settings.localIdentifier)
+    if (obj.local === true && (bsConfig.connection_settings.localIdentifier || bsConfig.connection_settings.local_identifier))
     {
-      obj.localIdentifier = bsConfig.connection_settings.localIdentifier;
+      obj.localIdentifier = bsConfig.connection_settings.localIdentifier || bsConfig.connection_settings.local_identifier;
       logger.log(`Local Identifier is set to: ${obj.localIdentifier}`);
     }
 
     // Project name
-    obj.project = bsConfig.run_settings.project
+    obj.project = bsConfig.run_settings.project || bsConfig.run_settings.project_name;
     if (!obj.project) logger.log(`Project name is: ${obj.project}`);
 
     // Base url
@@ -50,7 +50,7 @@ const caps = (bsConfig, zip) => {
     if (obj.base_url) logger.log(`Base url is : ${obj.base_url}`);
 
     // Build name
-    obj.customBuildName = bsConfig.run_settings.customBuildName
+    obj.customBuildName = bsConfig.run_settings.customBuildName || bsConfig.run_settings.build_name;
     if (obj.customBuildName) logger.log(`Build name is: ${obj.customBuildName}`);
 
     //callback url

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -45,10 +45,6 @@ const caps = (bsConfig, zip) => {
     obj.project = bsConfig.run_settings.project || bsConfig.run_settings.project_name;
     if (!obj.project) logger.log(`Project name is: ${obj.project}`);
 
-    // Base url
-    obj.base_url = bsConfig.run_settings.baseUrl
-    if (obj.base_url) logger.log(`Base url is : ${obj.base_url}`);
-
     // Build name
     obj.customBuildName = bsConfig.run_settings.customBuildName || bsConfig.run_settings.build_name;
     if (obj.customBuildName) logger.log(`Build name is: ${obj.customBuildName}`);

--- a/bin/templates/configTemplate.js
+++ b/bin/templates/configTemplate.js
@@ -13,12 +13,12 @@ module.exports = function () {
     ],
     "run_settings": {
       "cypress_proj_dir" : "/path/to/cypress.json",
-      "project": "project-name",
-      "customBuildName": "build-name"
+      "project_name": "project-name",
+      "build_name": "build-name"
     },
     "connection_settings": {
       "local": false,
-      "localIdentifier": null
+      "local_identifier": null
     }
   }
   var EOL = require('os').EOL


### PR DESCRIPTION
**User facing changelog**
*  The following keys are changed in browserstack.json 
    * `CustomBuildName` is changed to `build_name`
    * `project` is changed to `project_name`
    * `localIdentifier` is changed to `local_identifier`

The old key names will continue working for now.