### PR TITLE
CLI args options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ browserstack.json
 specs
 tests.zip
 package-lock.json
+.nyc_output/

--- a/bin/commands/info.js
+++ b/bin/commands/info.js
@@ -10,6 +10,12 @@ module.exports = function info(args) {
   let bsConfigPath = process.cwd() + args.cf;
 
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
+    // accept the username from command line if provided
+    utils.setUsername(bsConfig, args);
+
+    // accept the access key from command line if provided
+    utils.setAccessKey(bsConfig, args);
+
     utils.setUsageReportingFlag(bsConfig, args.disableUsageReporting);
 
     let buildId = args._[1];

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -15,6 +15,12 @@ module.exports = function run(args) {
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
     utils.setUsageReportingFlag(bsConfig, args.disableUsageReporting);
 
+    // accept the username from command line if provided
+    utils.setUsername(bsConfig, args);
+
+    // accept the access key from command line if provided
+    utils.setAccessKey(bsConfig, args);
+
     // Validate browserstack.json values and parallels specified via arguments
     return capabilityHelper.validate(bsConfig, args).then(function (validated) {
       logger.info(validated);

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -21,6 +21,9 @@ module.exports = function run(args) {
     // accept the access key from command line if provided
     utils.setAccessKey(bsConfig, args);
 
+    // accept the build name from command line if provided
+    utils.setBuildName(bsConfig, args);
+
     // Validate browserstack.json values and parallels specified via arguments
     return capabilityHelper.validate(bsConfig, args).then(function (validated) {
       logger.info(validated);

--- a/bin/commands/stop.js
+++ b/bin/commands/stop.js
@@ -10,6 +10,12 @@ module.exports = function stop(args) {
   let bsConfigPath = process.cwd() + args.cf;
 
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
+    // accept the username from command line if provided
+    utils.setUsername(bsConfig, args);
+
+    // accept the access key from command line if provided
+    utils.setAccessKey(bsConfig, args);
+
     utils.setUsageReportingFlag(bsConfig, args.disableUsageReporting);
 
     let buildId = args._[1];

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -66,7 +66,7 @@ const caps = (bsConfig, zip) => {
       obj.project = bsConfig.run_settings.project || bsConfig.run_settings.project_name;
       obj.customBuildName = bsConfig.run_settings.build_name || bsConfig.run_settings.customBuildName;
       obj.callbackURL = bsConfig.run_settings.callback_url;
-      obj.projectNotifyURL = bsConfig.run_settings.build_callback_url;
+      obj.projectNotifyURL = bsConfig.run_settings.project_notify_URL;
       obj.parallels = bsConfig.run_settings.parallels;
     }
 

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -66,7 +66,7 @@ const caps = (bsConfig, zip) => {
       obj.project = bsConfig.run_settings.project || bsConfig.run_settings.project_name;
       obj.customBuildName = bsConfig.run_settings.customBuildName || bsConfig.run_settings.build_name;
       obj.callbackURL = bsConfig.run_settings.callback_url;
-      obj.projectNotifyURL = bsConfig.run_settings.project_notify_URL;
+      obj.projectNotifyURL = bsConfig.run_settings.build_callback_url;
       obj.parallels = bsConfig.run_settings.parallels;
     }
 
@@ -99,7 +99,7 @@ const validate = (bsConfig, args) => {
 
     // validate parallels specified in browserstack.json if parallels are not specified via arguments
     if (!Utils.isUndefined(args) && Utils.isUndefined(args.parallels) && !Utils.isParallelValid(bsConfig.run_settings.parallels)) reject(Constants.validationMessages.INVALID_PARALLELS_CONFIGURATION);
-  
+
     // if parallels specified via arguments validate only arguments
     if (!Utils.isUndefined(args) && !Utils.isUndefined(args.parallels) && !Utils.isParallelValid(args.parallels)) reject(Constants.validationMessages.INVALID_PARALLELS_CONFIGURATION);
 
@@ -111,7 +111,7 @@ const validate = (bsConfig, args) => {
     }catch(error){
       reject(Constants.validationMessages.INVALID_CYPRESS_JSON)
     }
-    
+
     resolve(Constants.validationMessages.VALIDATED);
   });
 }

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -64,7 +64,7 @@ const caps = (bsConfig, zip) => {
 
     if (bsConfig.run_settings) {
       obj.project = bsConfig.run_settings.project || bsConfig.run_settings.project_name;
-      obj.customBuildName = bsConfig.run_settings.customBuildName || bsConfig.run_settings.build_name;
+      obj.customBuildName = bsConfig.run_settings.build_name || bsConfig.run_settings.customBuildName;
       obj.callbackURL = bsConfig.run_settings.callback_url;
       obj.projectNotifyURL = bsConfig.run_settings.build_callback_url;
       obj.parallels = bsConfig.run_settings.parallels;

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -52,10 +52,13 @@ const cliMessages = {
         PARALLEL_DESC: "The maximum number of parallels to use to run your test suite",
         INFO: "Run your tests on BrowserStack.",
         DESC: "Path to BrowserStack config",
-        CONFIG_DEMAND: "config file is required"
+        CONFIG_DEMAND: "config file is required",
+        BUILD_NAME: "The build name you want to use to name your test runs"
     },
     COMMON: {
-      DISABLE_USAGE_REPORTING: "Disable usage reporting"
+      DISABLE_USAGE_REPORTING: "Disable usage reporting",
+      USERNAME: "Your BrowserStack username",
+      ACCESS_KEY: "Your BrowserStack access key"
     }
 }
 

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -76,6 +76,18 @@ exports.setParallels = (bsConfig, args) => {
   }
 }
 
+exports.setUsername = (bsConfig, args) => {
+  if (!this.isUndefined(args.username)) {
+    bsConfig['auth']['username'] = args.username;
+  }
+}
+
+exports.setAccessKey = (bsConfig, args) => {
+  if (!this.isUndefined(args.key)) {
+    bsConfig['auth']['access_key'] = args.key;
+  }
+}
+
 exports.isUndefined = value => (value === undefined || value === null);
 
 exports.isFloat = value => (Number(value) && Number(value) % 1 !== 0);

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -103,5 +103,5 @@ exports.isParallelValid = (value) => {
 }
 
 exports.getUserAgent = () => {
-  return `BStack-Cypress-CLI/1.x (${os.arch()}/${os.platform()}/${os.release()})`;
+  return `BStack-Cypress-CLI/1.2.0 (${os.arch()}/${os.platform()}/${os.release()})`;
 }

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -88,6 +88,12 @@ exports.setAccessKey = (bsConfig, args) => {
   }
 }
 
+exports.setBuildName = (bsConfig, args) => {
+  if (!this.isUndefined(args['build-name'])) {
+    bsConfig['run_settings']['build_name'] = args['build-name'];
+  }
+}
+
 exports.isUndefined = value => (value === undefined || value === null);
 
 exports.isFloat = value => (Number(value) && Number(value) % 1 !== 0);

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -62,6 +62,18 @@ var argv = yargs
           description: Constants.cliMessages.COMMON.DISABLE_USAGE_REPORTING,
           type: "boolean"
         },
+        'u': {
+          alias: 'username',
+          describe: Constants.cliMessages.COMMON.USERNAME,
+          type: "string",
+          default: undefined
+        },
+        'k': {
+          alias: 'key',
+          describe: Constants.cliMessages.COMMON.ACCESS_KEY,
+          type: "string",
+          default: undefined
+        },
       })
       .help('help')
       .wrap(null)
@@ -89,6 +101,18 @@ var argv = yargs
           default: undefined,
           description: Constants.cliMessages.COMMON.DISABLE_USAGE_REPORTING,
           type: "boolean"
+        },
+        'u': {
+          alias: 'username',
+          describe: Constants.cliMessages.COMMON.USERNAME,
+          type: "string",
+          default: undefined
+        },
+        'k': {
+          alias: 'key',
+          describe: Constants.cliMessages.COMMON.ACCESS_KEY,
+          type: "string",
+          default: undefined
         },
       })
       .help('help')
@@ -121,6 +145,24 @@ var argv = yargs
           alias: 'parallels',
           describe: Constants.cliMessages.RUN.PARALLEL_DESC,
           type: "number",
+          default: undefined
+        },
+        'u': {
+          alias: 'username',
+          describe: Constants.cliMessages.COMMON.USERNAME,
+          type: "string",
+          default: undefined
+        },
+        'k': {
+          alias: 'key',
+          describe: Constants.cliMessages.COMMON.ACCESS_KEY,
+          type: "string",
+          default: undefined
+        },
+        'b': {
+          alias: 'build-name',
+          describe: Constants.cliMessages.RUN.BUILD_NAME,
+          type: "string",
           default: undefined
         }
       })

--- a/bin/templates/configTemplate.js
+++ b/bin/templates/configTemplate.js
@@ -1,8 +1,8 @@
 module.exports = function () {
   var config = {
     "auth": {
-      "username": "<username>",
-      "access_key": "<access-key>"
+      "username": "<Your BrowserStack username>",
+      "access_key": "<Your BrowserStack access key>"
     },
     "browsers": [
       {
@@ -12,7 +12,7 @@ module.exports = function () {
       }
     ],
     "run_settings": {
-      "cypress_proj_dir" : "/path/to/cypress.json",
+      "cypress_proj_dir" : "/path/to/directory-that-contains-<cypress.json>-file",
       "project_name": "project-name",
       "build_name": "build-name",
       "parallels": "Here goes the number of parallels you want to run",

--- a/test/unit/bin/commands/info.js
+++ b/test/unit/bin/commands/info.js
@@ -22,6 +22,8 @@ describe("buildInfo", () => {
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
@@ -45,6 +47,8 @@ describe("buildInfo", () => {
 
       const info = proxyquire("../../../../bin/commands/info", {
         "../helpers/utils": {
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
@@ -77,6 +81,8 @@ describe("buildInfo", () => {
 
       const info = proxyquire("../../../../bin/commands/info", {
         "../helpers/utils": {
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
@@ -103,6 +109,8 @@ describe("buildInfo", () => {
   describe("Handle statusCode != 200", () => {
     beforeEach(() => {
       sandbox = sinon.createSandbox();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
@@ -128,6 +136,8 @@ describe("buildInfo", () => {
 
       const info = proxyquire("../../../../bin/commands/info", {
         "../helpers/utils": {
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
@@ -166,6 +176,8 @@ describe("buildInfo", () => {
 
       const info = proxyquire("../../../../bin/commands/info", {
         "../helpers/utils": {
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
@@ -199,6 +211,8 @@ describe("buildInfo", () => {
 
       const info = proxyquire("../../../../bin/commands/info", {
         "../helpers/utils": {
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
@@ -227,6 +241,8 @@ describe("buildInfo", () => {
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
@@ -250,6 +266,8 @@ describe("buildInfo", () => {
 
       const info = proxyquire("../../../../bin/commands/info", {
         "../helpers/utils": {
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
@@ -277,6 +295,8 @@ describe("buildInfo", () => {
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -293,6 +313,8 @@ describe("buildInfo", () => {
     it("send usage report if validateBstackJson fails", () => {
       const info = proxyquire("../../../../bin/commands/info", {
         "../helpers/utils": {
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,

--- a/test/unit/bin/commands/runs.js
+++ b/test/unit/bin/commands/runs.js
@@ -75,6 +75,8 @@ describe("runs", () => {
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       validateBstackJsonStub = sandbox.stub();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -99,6 +101,8 @@ describe("runs", () => {
           getErrorCodeFromMsg: getErrorCodeFromMsgStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub
         },
         "../helpers/capabilityHelper": {
           validate: capabilityValidatorStub,
@@ -135,6 +139,8 @@ describe("runs", () => {
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       setParallelsStub = sandbox.stub();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -160,6 +166,8 @@ describe("runs", () => {
           validateBstackJson: validateBstackJsonStub,
           sendUsageReport: sendUsageReportStub,
           setParallels: setParallelsStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
         },
         "../helpers/capabilityHelper": {
@@ -207,6 +215,8 @@ describe("runs", () => {
       sandbox = sinon.createSandbox();
       validateBstackJsonStub = sandbox.stub();
       setParallelsStub = sandbox.stub();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -232,6 +242,8 @@ describe("runs", () => {
           validateBstackJson: validateBstackJsonStub,
           sendUsageReport: sendUsageReportStub,
           setParallels: setParallelsStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
         },
         "../helpers/capabilityHelper": {
@@ -287,6 +299,8 @@ describe("runs", () => {
       sandbox = sinon.createSandbox();
       validateBstackJsonStub = sandbox.stub();
       setParallelsStub = sandbox.stub();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -313,6 +327,8 @@ describe("runs", () => {
           validateBstackJson: validateBstackJsonStub,
           sendUsageReport: sendUsageReportStub,
           setParallels: setParallelsStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
         },
         "../helpers/capabilityHelper": {
@@ -378,6 +394,8 @@ describe("runs", () => {
       sandbox = sinon.createSandbox();
       validateBstackJsonStub = sandbox.stub();
       setParallelsStub = sandbox.stub();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -403,6 +421,8 @@ describe("runs", () => {
         "../helpers/utils": {
           validateBstackJson: validateBstackJsonStub,
           sendUsageReport: sendUsageReportStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           setParallels: setParallelsStub,
         },

--- a/test/unit/bin/commands/runs.js
+++ b/test/unit/bin/commands/runs.js
@@ -77,6 +77,7 @@ describe("runs", () => {
       validateBstackJsonStub = sandbox.stub();
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
+      setBuildNameStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -102,7 +103,8 @@ describe("runs", () => {
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           setUsername: setUsernameStub,
-          setAccessKey: setAccessKeyStub
+          setAccessKey: setAccessKeyStub,
+          setBuildName: setBuildNameStub
         },
         "../helpers/capabilityHelper": {
           validate: capabilityValidatorStub,
@@ -141,6 +143,7 @@ describe("runs", () => {
       setParallelsStub = sandbox.stub();
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
+      setBuildNameStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -168,6 +171,7 @@ describe("runs", () => {
           setParallels: setParallelsStub,
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
+          setBuildName: setBuildNameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
         },
         "../helpers/capabilityHelper": {
@@ -217,6 +221,7 @@ describe("runs", () => {
       setParallelsStub = sandbox.stub();
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
+      setBuildNameStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -244,6 +249,7 @@ describe("runs", () => {
           setParallels: setParallelsStub,
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
+          setBuildName: setBuildNameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
         },
         "../helpers/capabilityHelper": {
@@ -301,6 +307,7 @@ describe("runs", () => {
       setParallelsStub = sandbox.stub();
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
+      setBuildNameStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -329,6 +336,7 @@ describe("runs", () => {
           setParallels: setParallelsStub,
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
+          setBuildName: setBuildNameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
         },
         "../helpers/capabilityHelper": {
@@ -396,6 +404,7 @@ describe("runs", () => {
       setParallelsStub = sandbox.stub();
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
+      setBuildNameStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -423,6 +432,7 @@ describe("runs", () => {
           sendUsageReport: sendUsageReportStub,
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
+          setBuildName: setBuildNameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           setParallels: setParallelsStub,
         },

--- a/test/unit/bin/commands/stop.js
+++ b/test/unit/bin/commands/stop.js
@@ -23,6 +23,8 @@ describe("buildStop", () => {
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       validateBstackJsonStub = sandbox.stub();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -48,6 +50,8 @@ describe("buildStop", () => {
       const stop = proxyquire("../../../../bin/commands/stop", {
         "../helpers/utils": {
           validateBstackJson: validateBstackJsonStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
@@ -82,6 +86,8 @@ describe("buildStop", () => {
         "../helpers/utils": {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
@@ -106,6 +112,8 @@ describe("buildStop", () => {
   describe("Handle statusCode != 200", () => {
     beforeEach(() => {
       sandbox = sinon.createSandbox();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
@@ -134,6 +142,8 @@ describe("buildStop", () => {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
         },
@@ -174,6 +184,8 @@ describe("buildStop", () => {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
         },
@@ -209,6 +221,8 @@ describe("buildStop", () => {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
         },
@@ -234,6 +248,8 @@ describe("buildStop", () => {
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
@@ -262,6 +278,8 @@ describe("buildStop", () => {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
         },
@@ -287,6 +305,8 @@ describe("buildStop", () => {
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -306,6 +326,8 @@ describe("buildStop", () => {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
         },
       });

--- a/test/unit/bin/helpers/capabilityHelper.js
+++ b/test/unit/bin/helpers/capabilityHelper.js
@@ -233,7 +233,7 @@ describe("capabilityHelper.js", () => {
           project_name: "sample project",
           build_name: "sample build",
           callback_url: "random url",
-          build_callback_url: "random url",
+          project_notify_URL: "random url",
         },
       };
       return capabilityHelper

--- a/test/unit/bin/helpers/capabilityHelper.js
+++ b/test/unit/bin/helpers/capabilityHelper.js
@@ -233,7 +233,7 @@ describe("capabilityHelper.js", () => {
           project_name: "sample project",
           build_name: "sample build",
           callback_url: "random url",
-          project_notify_URL: "random url",
+          build_callback_url: "random url",
         },
       };
       return capabilityHelper
@@ -374,7 +374,7 @@ describe("capabilityHelper.js", () => {
       it("validate parallels present in bsconfig run settings (not a number) when not specified in arguments", () => {
 
         bsConfig.run_settings.parallels = "cypress";
-         
+
         return capabilityHelper
           .validate(bsConfig, { parallels: undefined })
           .then(function (data) {


### PR DESCRIPTION
1. `--username`/`-u` CLI arg where the user can specify  the username for `run`, `build-info`, and `build-stop` commands.
2. `--key`/`-k` CLI arg where the user can specify the access key for `run`, `build-info`, and `build-stop` commands.
3. `--build-name`/`-b` CLI arg where the user can specify the build name for `run` command.
4. Bump version to 1.2.0 for analytics.

- [x] Updates unit tests