### PR TITLE
[CYP-236] Change console message string if testings mins are expired

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -40,6 +40,9 @@ module.exports = function run(args) {
           });
         }).catch(function (err) {
           // Zip Upload failed
+          if (err === Constants.userMessages.INTERNAL_SERVER_ERROR) {
+            err = Constants.userMessages.TESTING_TIME_EXPIRED;
+          }
           logger.error(err);
           logger.error(Constants.userMessages.ZIP_UPLOAD_FAILED);
           utils.sendUsageReport(bsConfig, args, `${err}\n${Constants.userMessages.ZIP_UPLOAD_FAILED}`, Constants.messageTypes.ERROR, 'zip_upload_failed');

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -10,7 +10,9 @@ const userMessages = {
     ZIP_DELETE_FAILED: "Could not delete local file.",
     ZIP_DELETED: "Zip file deleted successfully.",
     API_DEPRECATED: "This version of API is deprecated, please use latest version of API.",
-    FAILED_TO_ZIP: "Failed to zip files."
+    FAILED_TO_ZIP: "Failed to zip files.",
+    TESTING_TIME_EXPIRED: "Automate testing time expired.",
+    INTERNAL_SERVER_ERROR: "Internal server error."
 };
 
 const validationMessages = {


### PR DESCRIPTION
**User facing changelog**
*  Update the error message from `internal server error` to `Automate testing minutes expired.` if automate testing mins are expired for the user