### PR TITLE
Handle absolute path and verify init path

### DIFF
--- a/bin/commands/info.js
+++ b/bin/commands/info.js
@@ -7,7 +7,7 @@ const config = require("../helpers/config"),
   utils = require("../helpers/utils");
 
 module.exports = function info(args) {
-  let bsConfigPath = process.cwd() + args.cf;
+  let bsConfigPath = utils.getConfigPath(args.cf);
 
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
     // accept the username from command line if provided

--- a/bin/commands/init.js
+++ b/bin/commands/init.js
@@ -18,12 +18,6 @@ module.exports = function init(args) {
     path: path_to_bsconf
   };
 
-  function allDone() {
-    let message = Constants.userMessages.CONFIG_FILE_CREATED
-    logger.info(message);
-    utils.sendUsageReport(null, args, message, Constants.messageTypes.SUCCESS, null);
-  }
-
   return fileHelpers.dirExists(config.path, function(dirExists){
     if (dirExists) {
       fileHelpers.fileExists(config.path, function(exists){
@@ -32,7 +26,7 @@ module.exports = function init(args) {
           logger.error(message);
           utils.sendUsageReport(null, args, message, Constants.messageTypes.ERROR, 'bstack_json_already_exists');
         } else {
-          fileHelpers.write(config, null, allDone);
+          fileHelpers.write(config, null, args, utils.configCreated);
         }
       });
     } else {

--- a/bin/commands/init.js
+++ b/bin/commands/init.js
@@ -2,7 +2,9 @@
 const fileHelpers = require("../helpers/fileHelpers"),
   Constants = require("../helpers/constants"),
   logger = require("../helpers/logger").winstonLogger,
-  utils = require("../helpers/utils");
+  utils = require("../helpers/utils"),
+  util = require("util"),
+  path = require('path');
 
 module.exports = function init(args) {
   if (args.p) {
@@ -34,7 +36,7 @@ module.exports = function init(args) {
         }
       });
     } else {
-      let message = Constants.userMessages.DIR_NOT_FOUND;
+      let message = util.format(Constants.userMessages.DIR_NOT_FOUND, path.dirname(config.path));
       logger.error(message);
       utils.sendUsageReport(null, args, message, Constants.messageTypes.ERROR, 'path_to_init_not_found');
     }

--- a/bin/commands/init.js
+++ b/bin/commands/init.js
@@ -22,13 +22,21 @@ module.exports = function init(args) {
     utils.sendUsageReport(null, args, message, Constants.messageTypes.SUCCESS, null);
   }
 
-  return fileHelpers.fileExists(config.path, function(exists){
-    if (exists) {
-      let message = Constants.userMessages.CONFIG_FILE_EXISTS;
-      logger.error(message);
-      utils.sendUsageReport(null, args, message, Constants.messageTypes.ERROR, 'bstack_json_already_exists');
+  return fileHelpers.dirExists(config.path, function(dirExists){
+    if (dirExists) {
+      fileHelpers.fileExists(config.path, function(exists){
+        if (exists) {
+          let message = Constants.userMessages.CONFIG_FILE_EXISTS;
+          logger.error(message);
+          utils.sendUsageReport(null, args, message, Constants.messageTypes.ERROR, 'bstack_json_already_exists');
+        } else {
+          fileHelpers.write(config, null, allDone);
+        }
+      });
     } else {
-      fileHelpers.write(config, null, allDone);
+      let message = Constants.userMessages.DIR_NOT_FOUND;
+      logger.error(message);
+      utils.sendUsageReport(null, args, message, Constants.messageTypes.ERROR, 'path_to_init_not_found');
     }
   });
 }

--- a/bin/commands/init.js
+++ b/bin/commands/init.js
@@ -8,7 +8,7 @@ const fileHelpers = require("../helpers/fileHelpers"),
 
 module.exports = function init(args) {
   if (args.p) {
-    var path_to_bsconf = args.p + "/browserstack.json";
+    var path_to_bsconf = path.join(args.p + "/browserstack.json");
   } else {
     var path_to_bsconf = "./browserstack.json";
   }

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -10,7 +10,7 @@ const archiver = require("../helpers/archiver"),
   fileHelpers = require("../helpers/fileHelpers");
 
 module.exports = function run(args) {
-  let bsConfigPath = process.cwd() + args.cf;
+  let bsConfigPath = utils.getConfigPath(args.cf);
 
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
     utils.setUsageReportingFlag(bsConfig, args.disableUsageReporting);

--- a/bin/commands/stop.js
+++ b/bin/commands/stop.js
@@ -7,7 +7,7 @@ const config = require("../helpers/config"),
   utils = require("../helpers/utils");
 
 module.exports = function stop(args) {
-  let bsConfigPath = process.cwd() + args.cf;
+  let bsConfigPath = utils.getConfigPath(args.cf);
 
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
     // accept the username from command line if provided

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -7,7 +7,7 @@ const userMessages = {
     ZIP_UPLOAD_FAILED: "Zip Upload failed.",
     CONFIG_FILE_CREATED: "BrowserStack Config File created, you can now run browserstack-cypress --config-file run",
     CONFIG_FILE_EXISTS: "File already exists, delete the browserstack.json file manually. skipping...",
-    DIR_NOT_FOUND: "Given path does not exist. Failed to create browserstack.json.",
+    DIR_NOT_FOUND: "Given path does not exist. Failed to create browserstack.json in %s",
     ZIP_DELETE_FAILED: "Could not delete local file.",
     ZIP_DELETED: "Zip file deleted successfully.",
     API_DEPRECATED: "This version of API is deprecated, please use latest version of API.",

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -7,6 +7,7 @@ const userMessages = {
     ZIP_UPLOAD_FAILED: "Zip Upload failed.",
     CONFIG_FILE_CREATED: "BrowserStack Config File created, you can now run browserstack-cypress --config-file run",
     CONFIG_FILE_EXISTS: "File already exists, delete the browserstack.json file manually. skipping...",
+    DIR_NOT_FOUND: "Given path does not exist. Failed to create browserstack.json.",
     ZIP_DELETE_FAILED: "Could not delete local file.",
     ZIP_DELETED: "Zip file deleted successfully.",
     API_DEPRECATED: "This version of API is deprecated, please use latest version of API.",

--- a/bin/helpers/fileHelpers.js
+++ b/bin/helpers/fileHelpers.js
@@ -6,11 +6,11 @@ const logger = require("./logger").winstonLogger,
   Constants = require("../helpers/constants"),
   config = require("../helpers/config");
 
-exports.write = function(f, message, cb) {
+exports.write = function(f, message, args, cb) {
   message = message || 'Creating';
   fs.writeFile(f.path, f.file, function() {
-    logger.info(message + " file: ./" + path.relative(process.cwd(), f.path));
-    cb && cb()
+    logger.info(message + " file: " + f.path);
+    cb && cb(args)
   });
 }
 

--- a/bin/helpers/fileHelpers.js
+++ b/bin/helpers/fileHelpers.js
@@ -35,3 +35,11 @@ exports.deleteZip = () => {
     }
   });
 }
+
+exports.dirExists = function (filePath, cb) {
+  let exists = false;
+  if (fs.existsSync(path.dirname(filePath), cb)) {
+    exists = true;
+  }
+  cb && cb(exists);
+}

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -1,5 +1,6 @@
 'use strict';
 const os = require("os");
+const path = require("path");
 
 const usageReporting =  require('./usageReporting'),
   logger = require('./logger').winstonLogger,
@@ -104,4 +105,18 @@ exports.isParallelValid = (value) => {
 
 exports.getUserAgent = () => {
   return `BStack-Cypress-CLI/1.2.0 (${os.arch()}/${os.platform()}/${os.release()})`;
+}
+
+exports.isAbsolute  = (configPath) => {
+  return path.isAbsolute(configPath)
+}
+
+exports.getConfigPath = (configPath) => {
+  return this.isAbsolute(configPath) ? configPath : path.join(process.cwd(), configPath);
+}
+
+exports.configCreated = (args) => {
+  let message = Constants.userMessages.CONFIG_FILE_CREATED
+  logger.info(message);
+  this.sendUsageReport(null, args, message, Constants.messageTypes.SUCCESS, null);
 }

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -51,7 +51,7 @@ var argv = yargs
         'cf': {
           alias: 'config-file',
           describe: Constants.cliMessages.BUILD.DESC,
-          default: '/browserstack.json',
+          default: 'browserstack.json',
           type: 'string',
           nargs: 1,
           demand: true,
@@ -91,7 +91,7 @@ var argv = yargs
         'cf': {
           alias: 'config-file',
           describe: Constants.cliMessages.BUILD.DESC,
-          default: '/browserstack.json',
+          default: 'browserstack.json',
           type: 'string',
           nargs: 1,
           demand: true,
@@ -130,7 +130,7 @@ var argv = yargs
         'cf': {
           alias: 'config-file',
           describe: Constants.cliMessages.RUN.DESC,
-          default: '/browserstack.json',
+          default: 'browserstack.json',
           type: 'string',
           nargs: 1,
           demand: true,

--- a/test/unit/bin/commands/info.js
+++ b/test/unit/bin/commands/info.js
@@ -25,6 +25,7 @@ describe("buildInfo", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -54,6 +55,7 @@ describe("buildInfo", () => {
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
+          getConfigPath: getConfigPathStub
         },
         request: { get: requestStub },
       });
@@ -63,6 +65,7 @@ describe("buildInfo", () => {
       return info(args)
         .then(function (_bsConfig) {
           sinon.assert.calledOnce(requestStub);
+          sinon.assert.calledOnce(getConfigPathStub);
           sinon.assert.calledOnce(getUserAgentStub);
           sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, message, messageType, errorCode);
         }).catch((error) => {
@@ -88,6 +91,7 @@ describe("buildInfo", () => {
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
+          getConfigPath: getConfigPathStub
         },
         request: { get: requestStub },
       });
@@ -98,6 +102,7 @@ describe("buildInfo", () => {
         .then(function (_bsConfig) {
           sinon.assert.calledOnce(requestStub);
           sinon.assert.calledOnce(getUserAgentStub);
+          sinon.assert.calledOnce(getConfigPathStub);
           sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, message, messageType, errorCode);
         })
         .catch((error) => {
@@ -112,6 +117,7 @@ describe("buildInfo", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -143,6 +149,7 @@ describe("buildInfo", () => {
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
+          getConfigPath: getConfigPathStub
         },
         request: { get: requestStub },
       });
@@ -153,6 +160,7 @@ describe("buildInfo", () => {
         .then(function (_bsConfig) {
           sinon.assert.calledOnce(requestStub);
           sinon.assert.calledOnce(getUserAgentStub);
+          sinon.assert.calledOnce(getConfigPathStub);
           sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, message, messageType, errorCode);
         })
         .catch((error) => {
@@ -183,6 +191,7 @@ describe("buildInfo", () => {
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
+          getConfigPath: getConfigPathStub
         },
         request: { get: requestStub },
       });
@@ -193,6 +202,7 @@ describe("buildInfo", () => {
         .then(function (_bsConfig) {
           sinon.assert.calledOnce(requestStub);
           sinon.assert.calledOnce(getUserAgentStub);
+          sinon.assert.calledOnce(getConfigPathStub);
           sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, message, messageType, errorCode);
         })
         .catch((error) => {
@@ -218,6 +228,7 @@ describe("buildInfo", () => {
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
+          getConfigPath: getConfigPathStub
         },
         request: { get: requestStub },
       });
@@ -228,6 +239,7 @@ describe("buildInfo", () => {
         .then(function (_bsConfig) {
           sinon.assert.calledOnce(requestStub);
           sinon.assert.calledOnce(getUserAgentStub);
+          sinon.assert.calledOnce(getConfigPathStub);
           sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, message, messageType, errorCode);
         })
         .catch((error) => {
@@ -244,6 +256,7 @@ describe("buildInfo", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -273,6 +286,7 @@ describe("buildInfo", () => {
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
+          getConfigPath: getConfigPathStub
         },
         request: { get: requestStub },
       });
@@ -283,6 +297,7 @@ describe("buildInfo", () => {
         .then(function (_bsConfig) {
           sinon.assert.calledOnce(requestStub);
           sinon.assert.calledOnce(getUserAgentStub);
+          sinon.assert.calledOnce(getConfigPathStub);
           sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, message, messageType, errorCode);
         }).catch((error) => {
           chai.assert.isNotOk(error,'Promise error');
@@ -297,6 +312,7 @@ describe("buildInfo", () => {
       sandbox = sinon.createSandbox();
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -319,6 +335,7 @@ describe("buildInfo", () => {
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          getConfigPath: getConfigPathStub
         },
       });
 

--- a/test/unit/bin/commands/init.js
+++ b/test/unit/bin/commands/init.js
@@ -15,20 +15,41 @@ describe("init", () => {
   let args = testObjects.initSampleArgs;
   var sandbox;
 
-  before(() => {
+  beforeEach(() => {
     sandbox = sinon.createSandbox();
     sendUsageReportStub = sandbox.stub().callsFake(function () {
       return "end";
     });
   });
 
-  after(() => {
+  afterEach(() => {
     sandbox.restore();
     sinon.restore();
   });
 
   describe("init", () => {
+    it("fail if given path is not present", () => {
+      dirExistsStub = sandbox.stub().yields(false);
+      writeStub = sandbox.stub();
+
+      const init = proxyquire("../../../../bin/commands/init", {
+        "../helpers/utils": {
+          sendUsageReport: sendUsageReportStub,
+        },
+        "../helpers/fileHelpers": {
+          dirExists: dirExistsStub,
+          write: writeStub,
+        },
+      });
+
+      init(args);
+      sinon.assert.calledOnce(dirExistsStub);
+      sinon.assert.notCalled(writeStub);
+      sinon.assert.calledOnceWithExactly(sendUsageReportStub, null, args, Constants.userMessages.DIR_NOT_FOUND, Constants.messageTypes.ERROR, 'path_to_init_not_found');
+    });
+
     it("fail if browserstack.json is already present", () => {
+      dirExistsStub = sandbox.stub().yields(true);
       fileExistsStub = sandbox.stub().yields(true);
       writeStub = sandbox.stub();
 
@@ -37,18 +58,21 @@ describe("init", () => {
           sendUsageReport: sendUsageReportStub,
         },
         "../helpers/fileHelpers": {
+          dirExists: dirExistsStub,
           fileExists: fileExistsStub,
           write: writeStub,
         },
       });
 
       init(args);
+      sinon.assert.calledOnce(dirExistsStub);
       sinon.assert.calledOnce(fileExistsStub);
       sinon.assert.notCalled(writeStub);
       sinon.assert.calledOnceWithExactly(sendUsageReportStub, null, args, Constants.userMessages.CONFIG_FILE_EXISTS, Constants.messageTypes.ERROR, 'bstack_json_already_exists');
     });
 
     it("create browserstack.json if not already present", () => {
+      dirExistsStub = sandbox.stub().yields(true);
       fileExistsStub = sandbox.stub().yields(false);
       writeStub = sandbox.stub();
 
@@ -57,12 +81,14 @@ describe("init", () => {
           sendUsageReport: sendUsageReportStub,
         },
         "../helpers/fileHelpers": {
+          dirExists: dirExistsStub,
           fileExists: fileExistsStub,
           write: writeStub,
         },
       });
 
       init(args);
+      sinon.assert.calledOnce(dirExistsStub);
       sinon.assert.calledOnce(fileExistsStub);
       sinon.assert.calledOnce(writeStub);
     });

--- a/test/unit/bin/commands/init.js
+++ b/test/unit/bin/commands/init.js
@@ -1,6 +1,7 @@
 const chai = require("chai"),
   sinon = require("sinon"),
-  chaiAsPromised = require("chai-as-promised");
+  chaiAsPromised = require("chai-as-promised"),
+  util = require("util");
 
 const Constants = require("../../../../bin/helpers/constants"),
   logger = require("../../../../bin/helpers/logger").winstonLogger,
@@ -32,6 +33,9 @@ describe("init", () => {
     it("fail if given path is not present", () => {
       dirExistsStub = sandbox.stub().yields(false);
       writeStub = sandbox.stub();
+      formatStub = sandbox.stub().callsFake(function (args) {
+        return args;
+      });
 
       const init = proxyquire("../../../../bin/commands/init", {
         "../helpers/utils": {
@@ -41,6 +45,9 @@ describe("init", () => {
           dirExists: dirExistsStub,
           write: writeStub,
         },
+        "util": {
+          format: formatStub
+        }
       });
 
       init(args);

--- a/test/unit/bin/commands/init.js
+++ b/test/unit/bin/commands/init.js
@@ -17,6 +17,7 @@ describe("init", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    configCreatedStub = sandbox.stub()
     sendUsageReportStub = sandbox.stub().callsFake(function () {
       return "end";
     });
@@ -79,6 +80,7 @@ describe("init", () => {
       const init = proxyquire("../../../../bin/commands/init", {
         "../helpers/utils": {
           sendUsageReport: sendUsageReportStub,
+          configCreated: configCreatedStub
         },
         "../helpers/fileHelpers": {
           dirExists: dirExistsStub,

--- a/test/unit/bin/commands/runs.js
+++ b/test/unit/bin/commands/runs.js
@@ -21,6 +21,7 @@ describe("runs", () => {
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       validateBstackJsonStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -44,6 +45,7 @@ describe("runs", () => {
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          getConfigPath: getConfigPathStub
         },
       });
 
@@ -54,6 +56,8 @@ describe("runs", () => {
           chai.assert.fail("Promise error");
         })
         .catch((error) => {
+          sinon.assert.calledOnce(getConfigPathStub);
+          sinon.assert.calledOnce(getConfigPathStub);
           sinon.assert.calledOnce(validateBstackJsonStub);
           sinon.assert.calledOnce(setUsageReportingFlagStub);
           sinon.assert.calledOnce(getErrorCodeFromErrStub);
@@ -78,6 +82,7 @@ describe("runs", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       setBuildNameStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -104,7 +109,8 @@ describe("runs", () => {
           setUsageReportingFlag: setUsageReportingFlagStub,
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
-          setBuildName: setBuildNameStub
+          setBuildName: setBuildNameStub,
+          getConfigPath: getConfigPathStub
         },
         "../helpers/capabilityHelper": {
           validate: capabilityValidatorStub,
@@ -119,6 +125,8 @@ describe("runs", () => {
           chai.assert.fail("Promise error");
         })
         .catch((error) => {
+          sinon.assert.calledOnce(getConfigPathStub);
+          sinon.assert.calledOnce(getConfigPathStub);
           sinon.assert.calledOnce(validateBstackJsonStub);
           sinon.assert.calledOnce(capabilityValidatorStub);
           sinon.assert.calledOnce(setUsageReportingFlagStub);
@@ -143,6 +151,7 @@ describe("runs", () => {
       setParallelsStub = sandbox.stub();
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setBuildNameStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
@@ -173,6 +182,7 @@ describe("runs", () => {
           setAccessKey: setAccessKeyStub,
           setBuildName: setBuildNameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          getConfigPath: getConfigPathStub
         },
         "../helpers/capabilityHelper": {
           validate: capabilityValidatorStub,
@@ -194,6 +204,8 @@ describe("runs", () => {
           chai.assert.fail("Promise error");
         })
         .catch((error) => {
+          sinon.assert.calledOnce(getConfigPathStub);
+          sinon.assert.calledOnce(getConfigPathStub);
           sinon.assert.calledOnce(setParallelsStub)
           sinon.assert.calledOnce(validateBstackJsonStub);
           sinon.assert.calledOnce(capabilityValidatorStub);
@@ -222,6 +234,7 @@ describe("runs", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       setBuildNameStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -251,6 +264,7 @@ describe("runs", () => {
           setAccessKey: setAccessKeyStub,
           setBuildName: setBuildNameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          getConfigPath: getConfigPathStub
         },
         "../helpers/capabilityHelper": {
           validate: capabilityValidatorStub,
@@ -276,6 +290,8 @@ describe("runs", () => {
           chai.assert.fail("Promise error");
         })
         .catch((error) => {
+          sinon.assert.calledOnce(getConfigPathStub);
+          sinon.assert.calledOnce(getConfigPathStub);
           sinon.assert.calledOnce(setParallelsStub);
           sinon.assert.calledOnce(validateBstackJsonStub);
           sinon.assert.calledOnce(capabilityValidatorStub);
@@ -308,6 +324,7 @@ describe("runs", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       setBuildNameStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -338,6 +355,7 @@ describe("runs", () => {
           setAccessKey: setAccessKeyStub,
           setBuildName: setBuildNameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          getConfigPath: getConfigPathStub
         },
         "../helpers/capabilityHelper": {
           validate: capabilityValidatorStub,
@@ -369,6 +387,8 @@ describe("runs", () => {
           chai.assert.fail("Promise error");
         })
         .catch((error) => {
+          sinon.assert.calledOnce(getConfigPathStub);
+          sinon.assert.calledOnce(getConfigPathStub);
           sinon.assert.calledOnce(validateBstackJsonStub);
           sinon.assert.calledOnce(capabilityValidatorStub);
           sinon.assert.calledOnce(setParallelsStub);
@@ -405,6 +425,7 @@ describe("runs", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       setBuildNameStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -435,6 +456,7 @@ describe("runs", () => {
           setBuildName: setBuildNameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           setParallels: setParallelsStub,
+          getConfigPath: getConfigPathStub
         },
         "../helpers/capabilityHelper": {
           validate: capabilityValidatorStub,
@@ -466,6 +488,8 @@ describe("runs", () => {
           chai.assert.fail("Promise error");
         })
         .catch((error) => {
+          sinon.assert.calledOnce(getConfigPathStub);
+          sinon.assert.calledOnce(getConfigPathStub);
           sinon.assert.calledOnce(validateBstackJsonStub);
           sinon.assert.calledOnce(capabilityValidatorStub);
           sinon.assert.calledOnce(setParallelsStub);

--- a/test/unit/bin/commands/stop.js
+++ b/test/unit/bin/commands/stop.js
@@ -25,6 +25,7 @@ describe("buildStop", () => {
       validateBstackJsonStub = sandbox.stub();
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -56,6 +57,7 @@ describe("buildStop", () => {
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
+          getConfigPath: getConfigPathStub
         },
         request: { post: requestStub },
       });
@@ -91,6 +93,7 @@ describe("buildStop", () => {
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
+          getConfigPath: getConfigPathStub
         },
         request: { post: requestStub },
       });
@@ -115,6 +118,7 @@ describe("buildStop", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -146,6 +150,7 @@ describe("buildStop", () => {
           setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
+          getConfigPath: getConfigPathStub
         },
         request: { post: requestStub },
       });
@@ -188,6 +193,7 @@ describe("buildStop", () => {
           setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
+          getConfigPath: getConfigPathStub
         },
         request: { post: requestStub },
       });
@@ -225,6 +231,7 @@ describe("buildStop", () => {
           setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
+          getConfigPath: getConfigPathStub
         },
         request: { post: requestStub },
       });
@@ -251,6 +258,7 @@ describe("buildStop", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -282,6 +290,7 @@ describe("buildStop", () => {
           setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getUserAgent: getUserAgentStub,
+          getConfigPath: getConfigPathStub
         },
         request: { post: requestStub },
       });
@@ -308,6 +317,7 @@ describe("buildStop", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
+      getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -329,6 +339,7 @@ describe("buildStop", () => {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          getConfigPath: getConfigPathStub
         },
       });
 

--- a/test/unit/bin/helpers/fileHelpers.js
+++ b/test/unit/bin/helpers/fileHelpers.js
@@ -38,7 +38,7 @@ describe("fileHelpers", () => {
       },
     });
 
-    fileHelpers.write("./random_path", "writing successful", callbackStub);
+    fileHelpers.write("./random_path", "writing successful", {}, callbackStub);
     sinon.assert.calledOnce(writeFileStub);
     expect(dataMock).to.eql(1);
   });

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -3,11 +3,13 @@ const path = require('path');
 
 const chai = require("chai"),
   expect = chai.expect,
+  sinon = require('sinon'),
   chaiAsPromised = require("chai-as-promised");
 
 const utils = require('../../../../bin/helpers/utils'),
   constant = require('../../../../bin/helpers/constants'),
-  logger = require('../../../../bin/helpers/logger').winstonLogger;
+  logger = require('../../../../bin/helpers/logger').winstonLogger,
+  testObjects = require("../../support/fixtures/testObjects");
 
 chai.use(chaiAsPromised);
 logger.transports["console.info"].silent = true;
@@ -35,7 +37,7 @@ describe("utils", () => {
       expect(utils.isParallelValid("1.2.2.2")).to.be.equal(false);
       expect(utils.isParallelValid("1.456789")).to.be.equal(false);
     });
-    
+
     it("should return false for a string which is not a number", () => {
       expect(utils.isParallelValid("cypress")).to.be.equal(false);
       expect(utils.isParallelValid("browserstack")).to.be.equal(false);
@@ -198,6 +200,40 @@ describe("utils", () => {
       };
       utils.setUsageReportingFlag(bsConfig, true);
       expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq("true");
+    });
+  });
+
+  describe("isAbsolute", () => {
+    it("should return true when path is absolute", () => {
+      expect(utils.isAbsolute("/Absolute/Path")).to.be.true;
+    });
+
+    it("should return false when path is relative", () => {
+      expect(utils.isAbsolute("../Relative/Path")).to.be.false;
+    });
+  });
+
+  describe("getConfigPath", () => {
+    it("should return given path, when path is absolute", () => {
+      expect(utils.getConfigPath("/Absolute/Path")).to.be.eq("/Absolute/Path");
+    });
+
+    it("should return path joined with current dir path, when path is relative", () => {
+      let configPath = "../Relative/Path"
+      expect(utils.getConfigPath(configPath)).to.be.eq(path.join(process.cwd(), configPath));
+    });
+  });
+
+  describe("configCreated", () => {
+    let args = testObjects.initSampleArgs;
+
+    it("should call sendUsageReport", () => {
+      sandbox = sinon.createSandbox();
+      sendUsageReportStub = sandbox.stub(utils, "sendUsageReport").callsFake(function () {
+        return "end";
+      });
+      utils.configCreated(args);
+      sinon.assert.calledOnce(sendUsageReportStub);
     });
   });
 });

--- a/test/unit/support/fixtures/testObjects.js
+++ b/test/unit/support/fixtures/testObjects.js
@@ -19,9 +19,9 @@ const initSampleArgs = {
 
 const buildInfoSampleArgs = {
   _: ["build-info", "f3c94f7203792d03a75be3912d19354fe0961e53"],
-  cf: "/browserstack.json",
-  "config-file": "/browserstack.json",
-  configFile: "/browserstack.json",
+  cf: "browserstack.json",
+  "config-file": "browserstack.json",
+  configFile: "browserstack.json",
   "disable-usage-reporting": undefined,
   disableUsageReporting: undefined,
   $0: "browserstack-cypress",
@@ -81,9 +81,9 @@ const buildInfoSampleBody = {
 
 const buildStopSampleArgs = {
   _: ["build-stop", "f3c94f7203792d03a75be3912d19354fe0961e53"],
-  cf: "/browserstack.json",
-  "config-file": "/browserstack.json",
-  configFile: "/browserstack.json",
+  cf: "browserstack.json",
+  "config-file": "browserstack.json",
+  configFile: "browserstack.json",
   "disable-usage-reporting": undefined,
   disableUsageReporting: undefined,
   $0: "browserstack-cypress",
@@ -100,9 +100,9 @@ const sampleCapsData = {
 
 const runSampleArgs = {
   _: ["run"],
-  cf: "/browserstack.json",
-  "config-file": "/browserstack.json",
-  configFile: "/browserstack.json",
+  cf: "browserstack.json",
+  "config-file": "browserstack.json",
+  configFile: "browserstack.json",
   "disable-usage-reporting": undefined,
   p: undefined,
   "parallels": undefined,


### PR DESCRIPTION
Changes:

- Handle absolute path in —config-file
- Fix logging in init command
- Check if a given path exists before creating the config file in init command