### PR TITLE
browser and OS list as default in the init template

### DIFF
--- a/bin/templates/configTemplate.js
+++ b/bin/templates/configTemplate.js
@@ -9,6 +9,46 @@ module.exports = function () {
         "browser": "chrome",
         "os": "Windows 10",
         "versions": ["78", "77"]
+      },
+      {
+        "browser": "firefox",
+        "os": "Windows 10",
+        "versions": ["74", "75"]
+      },
+      {
+        "browser": "edge",
+        "os": "Windows 10",
+        "versions": ["80", "81"]
+      },
+      {
+        "browser": "chrome",
+        "os": "OS X Mojave",
+        "versions": ["78", "77"]
+      },
+      {
+        "browser": "firefox",
+        "os": "OS X Mojave",
+        "versions": ["74", "75"]
+      },
+      {
+        "browser": "edge",
+        "os": "OS X Mojave",
+        "versions": ["80", "81"]
+      },
+      {
+        "browser": "chrome",
+        "os": "OS X Catalina",
+        "versions": ["78", "77"]
+      },
+      {
+        "browser": "firefox",
+        "os": "OS X Catalina",
+        "versions": ["74", "75"]
+      },
+      {
+        "browser": "edge",
+        "os": "OS X Catalina",
+        "versions": ["80", "81"]
       }
     ],
     "run_settings": {


### PR DESCRIPTION
Adding OS X, chrome, fireox, and edge browsers in the init template as default