### PR TITLE
Changes for Context Aware CLI

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -41,6 +41,12 @@ module.exports = function run(args) {
           return build.createBuild(bsConfig, zip).then(function (data) {
             let message = `${data.message}! ${Constants.userMessages.BUILD_CREATED} with build id: ${data.build_id}`;
             let dashboardLink = `${Constants.userMessages.VISIT_DASHBOARD} ${config.dashboardUrl}${data.build_id}`;
+            if ((utils.isUndefined(bsConfig.run_settings.parallels) && utils.isUndefined(args.parallels)) || (!utils.isUndefined(bsConfig.run_settings.parallels) && bsConfig.run_settings.parallels == Constants.constants.DEFAULT_PARALLEL_MESSAGE)) {
+              logger.warn(Constants.userMessages.NO_PARALLELS);
+            }
+
+            if(!args.disableNpmWarning && bsConfig.run_settings.npm_dependencies  && Object.keys(bsConfig.run_settings.npm_dependencies).length <= 0) logger.warn(Constants.userMessages.NO_NPM_DEPENDENCIES);
+    
             logger.info(message);
             logger.info(dashboardLink);
             utils.sendUsageReport(bsConfig, args, `${message}\n${dashboardLink}`, Constants.messageTypes.SUCCESS, null);

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -47,8 +47,7 @@ const caps = (bsConfig, zip) => {
 
     // Local Identifier
     obj.localIdentifier = null;
-    if (obj.local === true && (bsConfig.connection_settings.localIdentifier || bsConfig.connection_settings.local_identifier))
-    {
+    if (obj.local === true && (bsConfig.connection_settings.localIdentifier || bsConfig.connection_settings.local_identifier)) {
       obj.localIdentifier = bsConfig.connection_settings.localIdentifier || bsConfig.connection_settings.local_identifier;
       logger.log(`Local Identifier is set to: ${obj.localIdentifier}`);
     }
@@ -70,6 +69,8 @@ const caps = (bsConfig, zip) => {
       obj.parallels = bsConfig.run_settings.parallels;
     }
 
+    if(obj.parallels === Constants.constants.DEFAULT_PARALLEL_MESSAGE) obj.parallels = undefined
+    
     if (obj.project) logger.log(`Project name is: ${obj.project}`);
 
     if (obj.customBuildName) logger.log(`Build name is: ${obj.customBuildName}`);
@@ -86,10 +87,12 @@ const caps = (bsConfig, zip) => {
 }
 
 const validate = (bsConfig, args) => {
-  return new Promise(function(resolve, reject){
+  return new Promise(function (resolve, reject) {
     if (!bsConfig) reject(Constants.validationMessages.EMPTY_BROWSERSTACK_JSON);
 
     if (!bsConfig.auth) reject(Constants.validationMessages.INCORRECT_AUTH_PARAMS);
+
+    if( bsConfig.auth.username == "<Your BrowserStack username>" || bsConfig.auth.access_key == "<Your BrowserStack access key>" ) reject(Constants.validationMessages.INVALID_DEFAULT_AUTH_PARAMS);
 
     if (!bsConfig.browsers || bsConfig.browsers.length === 0) reject(Constants.validationMessages.EMPTY_BROWSER_LIST);
 
@@ -105,10 +108,16 @@ const validate = (bsConfig, args) => {
 
     if (!fs.existsSync(path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json'))) reject(Constants.validationMessages.CYPRESS_JSON_NOT_FOUND + bsConfig.run_settings.cypress_proj_dir);
 
-    try{
-      let cypressJson = fs.readFileSync(path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json'))
-      JSON.parse(cypressJson)
-    }catch(error){
+    try {
+      let cypressJson = fs.readFileSync(path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json'));
+      cypressJson = JSON.parse(cypressJson);
+      // Cypress Json Base Url & Local true check
+      if (!Utils.isUndefined(cypressJson.baseUrl) && cypressJson.baseUrl.includes("localhost")) reject(Constants.validationMessages.LOCAL_NOT_SET);
+      
+      // Detect if the user is not using the right directory structure, and throw an error
+      if (!Utils.isUndefined(cypressJson.integrationFolder) && !Utils.isCypressProjDirValid(bsConfig.run_settings.cypress_proj_dir,cypressJson.integrationFolder)) reject(Constants.validationMessages.INCORRECT_DIRECTORY_STRUCTURE);
+
+    } catch (error) {
       reject(Constants.validationMessages.INVALID_CYPRESS_JSON)
     }
 

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -112,7 +112,7 @@ const validate = (bsConfig, args) => {
       let cypressJson = fs.readFileSync(path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json'));
       cypressJson = JSON.parse(cypressJson);
       // Cypress Json Base Url & Local true check
-      if (!Utils.isUndefined(cypressJson.baseUrl) && cypressJson.baseUrl.includes("localhost")) reject(Constants.validationMessages.LOCAL_NOT_SET);
+      if (!Utils.isUndefined(cypressJson.baseUrl) && cypressJson.baseUrl.includes("localhost") && !Utils.getLocalFlag(bsConfig.connection_settings)) reject(Constants.validationMessages.LOCAL_NOT_SET);
       
       // Detect if the user is not using the right directory structure, and throw an error
       if (!Utils.isUndefined(cypressJson.integrationFolder) && !Utils.isCypressProjDirValid(bsConfig.run_settings.cypress_proj_dir,cypressJson.integrationFolder)) reject(Constants.validationMessages.INCORRECT_DIRECTORY_STRUCTURE);

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -98,7 +98,7 @@ const validate = (bsConfig, args) => {
 
     if (!bsConfig.run_settings) reject(Constants.validationMessages.EMPTY_RUN_SETTINGS);
 
-    if (!bsConfig.run_settings.cypress_proj_dir) reject(Constants.validationMessages.EMPTY_SPEC_FILES);
+    if (!bsConfig.run_settings.cypress_proj_dir) reject(Constants.validationMessages.EMPTY_CYPRESS_PROJ_DIR);
 
     // validate parallels specified in browserstack.json if parallels are not specified via arguments
     if (!Utils.isUndefined(args) && Utils.isUndefined(args.parallels) && !Utils.isParallelValid(bsConfig.run_settings.parallels)) reject(Constants.validationMessages.INVALID_PARALLELS_CONFIGURATION);

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -12,7 +12,9 @@ const userMessages = {
     ZIP_DELETED: "Zip file deleted successfully.",
     API_DEPRECATED: "This version of API is deprecated, please use latest version of API.",
     FAILED_TO_ZIP: "Failed to zip files.",
-    VISIT_DASHBOARD: "Visit the Automate dashboard for test reporting:"
+    VISIT_DASHBOARD: "Visit the Automate dashboard for test reporting:",
+    NO_PARALLELS: "Your tests will run sequentially. Read more about running your tests in parallel here: https://www.browserstack.com/docs/automate/cypress/run-tests-in-parallel",
+    NO_NPM_DEPENDENCIES: "No npm dependencies specified. Read more here: https://www.browserstack.com/docs/automate/cypress/npm-packages. You can suppress this warning by using --disable-npm-warning flag."
 };
 
 const validationMessages = {
@@ -28,7 +30,10 @@ const validationMessages = {
   INVALID_EXTENSION: "Invalid files, please remove these files and try again.",
   INVALID_PARALLELS_CONFIGURATION: "Invalid value specified for parallels to use. Maximum parallels to use should be a number greater than 0.",
   CYPRESS_JSON_NOT_FOUND: "cypress.json file is not found at cypress_proj_dir path ",
-  INVALID_CYPRESS_JSON: "cypress.json is not a valid json"
+  INVALID_CYPRESS_JSON: "cypress.json is not a valid json",
+  INVALID_DEFAULT_AUTH_PARAMS: "Your username and access key are required to run your tests on BrowserStack. Learn more at https://www.browserstack.com/docs/automate/cypress/authentication",
+  LOCAL_NOT_SET: "To test <baseUrl value> on BrowserStack, you will have to set up Local testing. Read more here: https://www.browserstack.com/docs/automate/cypress/local-testing",
+  INCORRECT_DIRECTORY_STRUCTURE: "No tests to run. Note that your Cypress tests should be in the same directory where the cypress.json exists."
 };
 
 const cliMessages = {
@@ -60,7 +65,8 @@ const cliMessages = {
     COMMON: {
       DISABLE_USAGE_REPORTING: "Disable usage reporting",
       USERNAME: "Your BrowserStack username",
-      ACCESS_KEY: "Your BrowserStack access key"
+      ACCESS_KEY: "Your BrowserStack access key",
+      NO_NPM_WARNING: "No NPM warning if npm_dependencies is empty"
     }
 }
 
@@ -73,9 +79,14 @@ const messageTypes = {
   NULL: null
 }
 
+const constants = {
+  DEFAULT_PARALLEL_MESSAGE: "Here goes the number of parallels you want to run"
+}
+
 module.exports = Object.freeze({
   userMessages,
   cliMessages,
   validationMessages,
   messageTypes,
+  constants
 });

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -23,7 +23,7 @@ const validationMessages = {
   EMPTY_TEST_SUITE: "Test suite is empty",
   EMPTY_BROWSERSTACK_JSON: "Empty browserstack.json",
   EMPTY_RUN_SETTINGS: "Empty run settings",
-  EMPTY_SPEC_FILES: "No spec files specified in run_settings",
+  EMPTY_CYPRESS_PROJ_DIR: "cypress_proj_dir is not set in run_settings. See https://www.browserstack.com/docs/automate/cypress/sample-tutorial to learn more.",
   VALIDATED: "browserstack.json file is validated",
   NOT_VALID: "browerstack.json is not valid",
   NOT_VALID_JSON: "browerstack.json is not a valid json",

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -34,8 +34,8 @@ exports.getErrorCodeFromMsg = (errMsg) => {
     case Constants.validationMessages.EMPTY_RUN_SETTINGS:
       errorCode = "bstack_json_invalid_no_run_settings";
       break;
-    case Constants.validationMessages.EMPTY_SPEC_FILES:
-      errorCode = "bstack_json_invalid_values";
+    case Constants.validationMessages.EMPTY_CYPRESS_PROJ_DIR:
+      errorCode = "bstack_json_invalid_no_cypress_proj_dir";
       break;
     case Constants.validationMessages.INVALID_DEFAULT_AUTH_PARAMS:
       errorCode = "bstack_json_default_auth_keys";

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -140,8 +140,8 @@ exports.isCypressProjDirValid = (cypressDir, cypressProjDir) => {
   // Getting absolute path
   cypressDir = path.resolve(cypressDir);
   cypressProjDir = path.resolve(cypressProjDir);
-
   if(cypressProjDir === cypressDir) return true;
-  let parentTokens = cypressDir.split('/').filter(i => i.length)
-  return parentTokens.every((t, i) => cypressProjDir.split('/')[i] === t)
+  let parentTokens = cypressDir.split('/').filter(i => i.length);
+  let childTokens = cypressProjDir.split('/').filter(i => i.length);
+  return parentTokens.every((t, i) => childTokens[i] === t);
 }

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -14,7 +14,7 @@ exports.validateBstackJson = (bsConfigPath) => {
       resolve(bsConfig);
     }
     catch (e) {
-      reject(e);
+      reject("Couldn't find the browserstack.json file at \""+ bsConfigPath +"\". Please use --config-file <path to browserstack.json>.");
     }
   });
 }
@@ -37,6 +37,21 @@ exports.getErrorCodeFromMsg = (errMsg) => {
     case Constants.validationMessages.EMPTY_SPEC_FILES:
       errorCode = "bstack_json_invalid_values";
       break;
+    case Constants.validationMessages.INVALID_DEFAULT_AUTH_PARAMS:
+      errorCode = "bstack_json_default_auth_keys";
+      break;
+    case Constants.validationMessages.INVALID_PARALLELS_CONFIGURATION:
+      errorCode = "invalid_parallels_specified";
+      break;
+    case Constants.validationMessages.LOCAL_NOT_SET:
+      errorCode = "cypress_json_base_url_no_local";
+      break;
+    case Constants.validationMessages.INCORRECT_DIRECTORY_STRUCTURE:
+      errorCode = "invalid_directory_structure";
+      break;
+  }
+  if(errMsg.includes("Please use --config-file <path to browserstack.json>.")){
+    errorCode = "bstack_json_path_invalid";
   }
   return errorCode;
 }
@@ -100,7 +115,7 @@ exports.isUndefined = value => (value === undefined || value === null);
 exports.isFloat = value => (Number(value) && Number(value) % 1 !== 0);
 
 exports.isParallelValid = (value) => {
-  return this.isUndefined(value) || !(isNaN(value) || this.isFloat(value) || parseInt(value, 10) === 0 || parseInt(value, 10) < -1);
+  return this.isUndefined(value) || !(isNaN(value) || this.isFloat(value) || parseInt(value, 10) === 0 || parseInt(value, 10) < -1 ) || value === Constants.constants.DEFAULT_PARALLEL_MESSAGE;
 }
 
 exports.getUserAgent = () => {
@@ -119,4 +134,14 @@ exports.configCreated = (args) => {
   let message = Constants.userMessages.CONFIG_FILE_CREATED
   logger.info(message);
   this.sendUsageReport(null, args, message, Constants.messageTypes.SUCCESS, null);
+}
+
+exports.isCypressProjDirValid = (cypressDir, cypressProjDir) => {
+  // Getting absolute path
+  cypressDir = path.resolve(cypressDir);
+  cypressProjDir = path.resolve(cypressProjDir);
+
+  if(cypressProjDir === cypressDir) return true;
+  let parentTokens = cypressDir.split('/').filter(i => i.length)
+  return parentTokens.every((t, i) => cypressProjDir.split('/')[i] === t)
 }

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -145,3 +145,7 @@ exports.isCypressProjDirValid = (cypressDir, cypressProjDir) => {
   let childTokens = cypressProjDir.split('/').filter(i => i.length);
   return parentTokens.every((t, i) => childTokens[i] === t);
 }
+
+exports.getLocalFlag = (connectionSettings) => {
+  return !this.isUndefined(connectionSettings) && !this.isUndefined(connectionSettings.local) && connectionSettings.local
+}

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -164,6 +164,11 @@ var argv = yargs
           describe: Constants.cliMessages.RUN.BUILD_NAME,
           type: "string",
           default: undefined
+        },
+        'disable-npm-warning': {
+          default: false,
+          description: Constants.cliMessages.COMMON.NO_NPM_WARNING,
+          type: "boolean"
         }
       })
       .help('help')

--- a/test/unit/bin/commands/runs.js
+++ b/test/unit/bin/commands/runs.js
@@ -436,6 +436,7 @@ describe("runs", () => {
       zipUploadStub = sandbox.stub();
       createBuildStub = sandbox.stub();
       deleteZipStub = sandbox.stub();
+      isUndefinedStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -458,7 +459,8 @@ describe("runs", () => {
           setBuildName: setBuildNameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           setParallels: setParallelsStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
+          isUndefined: isUndefinedStub
         },
         "../helpers/capabilityHelper": {
           validate: capabilityValidatorStub,

--- a/test/unit/bin/helpers/capabilityHelper.js
+++ b/test/unit/bin/helpers/capabilityHelper.js
@@ -504,7 +504,7 @@ describe("capabilityHelper.js", () => {
     it("validate bsConfig", () => {
       let bsConfig = undefined;
       return capabilityHelper
-        .validate(bsConfig, {parallels: undefined})
+        .validate(bsConfig, { parallels: undefined })
         .then(function (data) {
           chai.assert.fail("Promise error");
         })
@@ -516,7 +516,7 @@ describe("capabilityHelper.js", () => {
     it("validate bsConfig.auth", () => {
       bsConfig = {};
       return capabilityHelper
-        .validate(bsConfig, {parallels: undefined})
+        .validate(bsConfig, { parallels: undefined })
         .then(function (data) {
           chai.assert.fail("Promise error");
         })
@@ -536,7 +536,7 @@ describe("capabilityHelper.js", () => {
         }
       };
       return capabilityHelper
-        .validate(bsConfig, {parallels: undefined})
+        .validate(bsConfig, { parallels: undefined })
         .then(function (data) {
           chai.assert.fail("Promise error");
         })
@@ -554,7 +554,7 @@ describe("capabilityHelper.js", () => {
         browsers: [],
       };
       return capabilityHelper
-        .validate(bsConfig, {parallels: undefined})
+        .validate(bsConfig, { parallels: undefined })
         .then(function (data) {
           chai.assert.fail("Promise error");
         })
@@ -578,7 +578,7 @@ describe("capabilityHelper.js", () => {
         ],
       };
       return capabilityHelper
-        .validate(bsConfig, {parallels: undefined})
+        .validate(bsConfig, { parallels: undefined })
         .then(function (data) {
           chai.assert.fail("Promise error");
         })
@@ -604,7 +604,7 @@ describe("capabilityHelper.js", () => {
       };
 
       return capabilityHelper
-        .validate(bsConfig, {parallels: undefined})
+        .validate(bsConfig, { parallels: undefined })
         .then(function (data) {
           chai.assert.fail("Promise error");
         })
@@ -631,13 +631,107 @@ describe("capabilityHelper.js", () => {
         },
       };
       capabilityHelper
-        .validate(bsConfig, {parallels: undefined})
+        .validate(bsConfig, { parallels: undefined })
         .then(function (data) {
           chai.assert.equal(data, Constants.validationMessages.VALIDATED);
         })
         .catch((error) => {
           chai.assert.fail("Promise error");
         });
+    });
+    describe("validate cypress.json", () => {
+      beforeEach(() => {
+        bsConfig = {
+          auth: {},
+          browsers: [
+            {
+              browser: "chrome",
+              os: "Windows 10",
+              versions: ["78", "77"],
+            },
+          ],
+          run_settings: {
+            cypress_proj_dir: "random path"
+          },
+        };
+      });
+      it("validate cypress json is present", () => {
+        //Stub for cypress json validation
+        sinon.stub(fs, 'existsSync').returns(false);
+
+        return capabilityHelper
+          .validate(bsConfig, { parallels: undefined })
+          .then(function (data) {
+            chai.assert.fail("Promise error");
+          })
+          .catch((error) => {
+            chai.assert.equal(
+              error,
+              Constants.validationMessages.CYPRESS_JSON_NOT_FOUND + "random path"
+            );
+            fs.existsSync.restore();
+          });
+      });
+
+      it("validate cypress json is valid", () => {
+        //Stub for cypress json validation
+        sinon.stub(fs, 'existsSync').returns(true);
+        sinon.stub(fs, 'readFileSync').returns("{invalid}");
+
+        return capabilityHelper
+          .validate(bsConfig, { parallels: undefined })
+          .then(function (data) {
+            chai.assert.fail("Promise error");
+          })
+          .catch((error) => {
+            chai.assert.equal(
+              error,
+              Constants.validationMessages.INVALID_CYPRESS_JSON
+            );
+            fs.existsSync.restore();
+            fs.readFileSync.restore();
+          });
+      });
+
+      it("validate baseUrl is set to localhost and local is not set to true", () => {
+        //Stub for cypress json validation
+        sinon.stub(fs, 'existsSync').returns(true);
+        sinon.stub(fs, 'readFileSync').returns('{ "baseUrl": "http://localhost:3000"}');
+
+        return capabilityHelper
+          .validate(bsConfig, { parallels: undefined })
+          .then(function (data) {
+            chai.assert.fail("Promise error");
+          })
+          .catch((error) => {
+            chai.assert.equal(
+              error,
+              Constants.validationMessages.LOCAL_NOT_SET
+            );
+            fs.existsSync.restore();
+            fs.readFileSync.restore();
+          });
+      });
+
+      it("validate integrationFolder is set and is accessible from cypress_proj_dir", () => {
+        //Stub for cypress json validation
+        sinon.stub(fs, 'existsSync').returns(true);
+        sinon.stub(fs, 'readFileSync').returns('{ "integrationFolder": "/absolute/path"}');
+
+        return capabilityHelper
+          .validate(bsConfig, { parallels: undefined })
+          .then(function (data) {
+            chai.assert.fail("Promise error");
+          })
+          .catch((error) => {
+            chai.assert.equal(
+              error,
+              Constants.validationMessages.INCORRECT_DIRECTORY_STRUCTURE
+            );
+            fs.existsSync.restore();
+            fs.readFileSync.restore();
+          });
+      });
     });
   });
 });

--- a/test/unit/bin/helpers/capabilityHelper.js
+++ b/test/unit/bin/helpers/capabilityHelper.js
@@ -528,6 +528,26 @@ describe("capabilityHelper.js", () => {
         });
     });
 
+    it("validate default bsConfig.auth", () => {
+      bsConfig = {
+        auth: {
+          username: "<Your BrowserStack username>",
+          access_key: "<Your BrowserStack access key>"
+        }
+      };
+      return capabilityHelper
+        .validate(bsConfig, {parallels: undefined})
+        .then(function (data) {
+          chai.assert.fail("Promise error");
+        })
+        .catch((error) => {
+          chai.assert.equal(
+            error,
+            Constants.validationMessages.INVALID_DEFAULT_AUTH_PARAMS
+          );
+        });
+    });
+
     it("validate bsConfig.browsers", () => {
       let bsConfig = {
         auth: {},

--- a/test/unit/bin/helpers/capabilityHelper.js
+++ b/test/unit/bin/helpers/capabilityHelper.js
@@ -611,7 +611,7 @@ describe("capabilityHelper.js", () => {
         .catch((error) => {
           chai.assert.equal(
             error,
-            Constants.validationMessages.EMPTY_SPEC_FILES
+            Constants.validationMessages.EMPTY_CYPRESS_PROJ_DIR
           );
         });
     });

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -236,4 +236,18 @@ describe("utils", () => {
       sinon.assert.calledOnce(sendUsageReportStub);
     });
   });
+
+  describe("isCypressProjDirValid", () => {
+    it("should return true when cypressDir and cypressProjDir is same", () =>{
+      expect(utils.isCypressProjDirValid("/absolute/path","/absolute/path")).to.be.true;
+    });
+
+    it("should return true when cypressProjDir is child directory of cypressDir", () =>{
+      expect(utils.isCypressProjDirValid("/absolute/path","/absolute/path/childpath")).to.be.true;
+    });
+
+    it("should return false when cypressProjDir is not child directory of cypressDir", () =>{
+      expect(utils.isCypressProjDirValid("/absolute/path","/absolute")).to.be.false;
+    });
+  });
 });

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -255,4 +255,22 @@ describe("utils", () => {
       expect(utils.isCypressProjDirValid("/absolute/path","/absolute")).to.be.false;
     });
   });
+
+  describe("getLocalFlag", () => {
+    it("should return false if connectionSettings is undefined", () => {
+      expect(utils.getLocalFlag(undefined)).to.be.false;
+    });
+
+    it("should return false if connectionSettings.local is undefined", () => {
+      expect(utils.getLocalFlag({})).to.be.false;
+    });
+
+    it("should return false if connectionSettings.local is false", () => {
+      expect(utils.getLocalFlag({"local": false})).to.be.false;
+    });
+
+    it("should return true if connectionSettings.local is true", () => {
+      expect(utils.getLocalFlag({"local": true})).to.be.true;
+    });
+  });
 });

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -25,7 +25,7 @@ describe("utils", () => {
       expect(utils.getErrorCodeFromMsg(constant.validationMessages.INCORRECT_AUTH_PARAMS)).to.eq("bstack_json_invalid_missing_keys");
       expect(utils.getErrorCodeFromMsg(constant.validationMessages.EMPTY_BROWSER_LIST)).to.eq("bstack_json_invalid_no_browsers");
       expect(utils.getErrorCodeFromMsg(constant.validationMessages.EMPTY_RUN_SETTINGS)).to.eq("bstack_json_invalid_no_run_settings");
-      expect(utils.getErrorCodeFromMsg(constant.validationMessages.EMPTY_SPEC_FILES)).to.eq("bstack_json_invalid_values");
+      expect(utils.getErrorCodeFromMsg(constant.validationMessages.EMPTY_CYPRESS_PROJ_DIR)).to.eq("bstack_json_invalid_no_cypress_proj_dir");
       expect(utils.getErrorCodeFromMsg(constant.validationMessages.INVALID_DEFAULT_AUTH_PARAMS)).to.eq("bstack_json_default_auth_keys");
       expect(utils.getErrorCodeFromMsg(constant.validationMessages.INVALID_PARALLELS_CONFIGURATION)).to.eq("invalid_parallels_specified");
       expect(utils.getErrorCodeFromMsg(constant.validationMessages.LOCAL_NOT_SET)).to.eq("cypress_json_base_url_no_local");

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -26,6 +26,11 @@ describe("utils", () => {
       expect(utils.getErrorCodeFromMsg(constant.validationMessages.EMPTY_BROWSER_LIST)).to.eq("bstack_json_invalid_no_browsers");
       expect(utils.getErrorCodeFromMsg(constant.validationMessages.EMPTY_RUN_SETTINGS)).to.eq("bstack_json_invalid_no_run_settings");
       expect(utils.getErrorCodeFromMsg(constant.validationMessages.EMPTY_SPEC_FILES)).to.eq("bstack_json_invalid_values");
+      expect(utils.getErrorCodeFromMsg(constant.validationMessages.INVALID_DEFAULT_AUTH_PARAMS)).to.eq("bstack_json_default_auth_keys");
+      expect(utils.getErrorCodeFromMsg(constant.validationMessages.INVALID_PARALLELS_CONFIGURATION)).to.eq("invalid_parallels_specified");
+      expect(utils.getErrorCodeFromMsg(constant.validationMessages.LOCAL_NOT_SET)).to.eq("cypress_json_base_url_no_local");
+      expect(utils.getErrorCodeFromMsg(constant.validationMessages.INCORRECT_DIRECTORY_STRUCTURE)).to.eq("invalid_directory_structure");
+      expect(utils.getErrorCodeFromMsg("Please use --config-file <path to browserstack.json>.")).to.eq("bstack_json_path_invalid");
     });
   });
 


### PR DESCRIPTION
Adding Validation & Warning Messages on CLI. 

1. Validate default username and access key.
2. Ignore the default string for parallels and throw a warning
3. Throw a better error instead of module not found in the CLI when browserstack.json is not found.
4. Throw an error if the baseUrl is http[s]://localhost:*and local is not set to true.
5. Throw a warning when there are no NPM dependencies.
6. Detect if the user is not using the right directory structure, and throw an error.
7. Error Code in BQ for Invalid Parallels .
