### PR TITLE
Cypress config file support

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -24,6 +24,9 @@ module.exports = function run(args) {
     // accept the build name from command line if provided
     utils.setBuildName(bsConfig, args);
 
+    // set cypress config filename
+    utils.setCypressConfigFilename(bsConfig, args);
+
     // Validate browserstack.json values and parallels specified via arguments
     return capabilityHelper.validate(bsConfig, args).then(function (validated) {
       logger.info(validated);

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -110,7 +110,9 @@ const validate = (bsConfig, args) => {
 
     if (!bsConfig.run_settings) reject(Constants.validationMessages.EMPTY_RUN_SETTINGS);
 
-    if (!bsConfig.run_settings.cypress_proj_dir) reject(Constants.validationMessages.EMPTY_CYPRESS_PROJ_DIR);
+    if (!bsConfig.run_settings.cypress_proj_dir && !bsConfig.run_settings.userProvidedCypessConfigFile) {
+      reject(Constants.validationMessages.EMPTY_CYPRESS_PROJ_DIR);
+    }
 
     // validate parallels specified in browserstack.json if parallels are not specified via arguments
     if (!Utils.isUndefined(args) && Utils.isUndefined(args.parallels) && !Utils.isParallelValid(bsConfig.run_settings.parallels)) reject(Constants.validationMessages.INVALID_PARALLELS_CONFIGURATION);
@@ -119,10 +121,10 @@ const validate = (bsConfig, args) => {
     if (!Utils.isUndefined(args) && !Utils.isUndefined(args.parallels) && !Utils.isParallelValid(args.parallels)) reject(Constants.validationMessages.INVALID_PARALLELS_CONFIGURATION);
 
     // validate if config file provided exists or not when cypress_config_file provided
-    // validate existing cypress_proj_dir key otherwise.
+    // validate the cypressProjectDir key otherwise.
     let cypressConfigFilePath = bsConfig.run_settings.cypressConfigFilePath;
 
-    if (!fs.existsSync(cypressConfigFilePath) && bsConfig.run_settings.cypress_config_filename !== 'false') reject(Constants.validationMessages.CYPRESS_JSON_NOT_FOUND + cypressConfigFilePath);
+    if (!fs.existsSync(cypressConfigFilePath) && bsConfig.run_settings.cypress_config_filename !== 'false') reject(Constants.validationMessages.INVALID_CYPRESS_CONFIG_FILE);
 
     try {
       if (bsConfig.run_settings.cypress_config_filename !== 'false') {
@@ -133,7 +135,7 @@ const validate = (bsConfig, args) => {
         if (!Utils.isUndefined(cypressJson.baseUrl) && cypressJson.baseUrl.includes("localhost") && !Utils.getLocalFlag(bsConfig.connection_settings)) reject(Constants.validationMessages.LOCAL_NOT_SET);
 
         // Detect if the user is not using the right directory structure, and throw an error
-        if (!Utils.isUndefined(cypressJson.integrationFolder) && !Utils.isCypressProjDirValid(bsConfig.run_settings.cypress_proj_dir,cypressJson.integrationFolder)) reject(Constants.validationMessages.INCORRECT_DIRECTORY_STRUCTURE);
+        if (!Utils.isUndefined(cypressJson.integrationFolder) && !Utils.isCypressProjDirValid(bsConfig.run_settings.cypressProjectDir,cypressJson.integrationFolder)) reject(Constants.validationMessages.INCORRECT_DIRECTORY_STRUCTURE);
       }
     } catch(error){
       reject(Constants.validationMessages.INVALID_CYPRESS_JSON)

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -67,10 +67,14 @@ const caps = (bsConfig, zip) => {
       obj.callbackURL = bsConfig.run_settings.callback_url;
       obj.projectNotifyURL = bsConfig.run_settings.project_notify_URL;
       obj.parallels = bsConfig.run_settings.parallels;
+
+      if (bsConfig.run_settings.cypress_config_filename) {
+        obj.cypress_config_filename = bsConfig.run_settings.cypress_config_filename;
+      }
     }
 
     if(obj.parallels === Constants.constants.DEFAULT_PARALLEL_MESSAGE) obj.parallels = undefined
-    
+
     if (obj.project) logger.log(`Project name is: ${obj.project}`);
 
     if (obj.customBuildName) logger.log(`Build name is: ${obj.customBuildName}`);
@@ -106,18 +110,24 @@ const validate = (bsConfig, args) => {
     // if parallels specified via arguments validate only arguments
     if (!Utils.isUndefined(args) && !Utils.isUndefined(args.parallels) && !Utils.isParallelValid(args.parallels)) reject(Constants.validationMessages.INVALID_PARALLELS_CONFIGURATION);
 
-    if (!fs.existsSync(path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json'))) reject(Constants.validationMessages.CYPRESS_JSON_NOT_FOUND + bsConfig.run_settings.cypress_proj_dir);
+    // validate if config file provided exists or not when cypress_config_file provided
+    // validate existing cypress_proj_dir key otherwise.
+    let cypressConfigFilePath = bsConfig.run_settings.cypressConfigFilePath;
+
+    if (!fs.existsSync(cypressConfigFilePath) && bsConfig.run_settings.cypress_config_filename !== 'false') reject(Constants.validationMessages.CYPRESS_JSON_NOT_FOUND + cypressConfigFilePath);
 
     try {
-      let cypressJson = fs.readFileSync(path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json'));
-      cypressJson = JSON.parse(cypressJson);
-      // Cypress Json Base Url & Local true check
-      if (!Utils.isUndefined(cypressJson.baseUrl) && cypressJson.baseUrl.includes("localhost") && !Utils.getLocalFlag(bsConfig.connection_settings)) reject(Constants.validationMessages.LOCAL_NOT_SET);
-      
-      // Detect if the user is not using the right directory structure, and throw an error
-      if (!Utils.isUndefined(cypressJson.integrationFolder) && !Utils.isCypressProjDirValid(bsConfig.run_settings.cypress_proj_dir,cypressJson.integrationFolder)) reject(Constants.validationMessages.INCORRECT_DIRECTORY_STRUCTURE);
+      if (bsConfig.run_settings.cypress_config_filename !== 'false') {
+        let cypressJsonContent = fs.readFileSync(cypressConfigFilePath);
+        cypressJson = JSON.parse(cypressJsonContent);
 
-    } catch (error) {
+        // Cypress Json Base Url & Local true check
+        if (!Utils.isUndefined(cypressJson.baseUrl) && cypressJson.baseUrl.includes("localhost") && !Utils.getLocalFlag(bsConfig.connection_settings)) reject(Constants.validationMessages.LOCAL_NOT_SET);
+
+        // Detect if the user is not using the right directory structure, and throw an error
+        if (!Utils.isUndefined(cypressJson.integrationFolder) && !Utils.isCypressProjDirValid(bsConfig.run_settings.cypress_proj_dir,cypressJson.integrationFolder)) reject(Constants.validationMessages.INCORRECT_DIRECTORY_STRUCTURE);
+      }
+    } catch(error){
       reject(Constants.validationMessages.INVALID_CYPRESS_JSON)
     }
 

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -29,6 +29,7 @@ const validationMessages = {
   NOT_VALID_JSON: "browerstack.json is not a valid json",
   INVALID_EXTENSION: "Invalid files, please remove these files and try again.",
   INVALID_PARALLELS_CONFIGURATION: "Invalid value specified for parallels to use. Maximum parallels to use should be a number greater than 0.",
+  INVALID_CYPRESS_CONFIG_FILE: "Invalid cypress_config_file",
   CYPRESS_JSON_NOT_FOUND: "cypress.json file is not found at cypress_proj_dir path ",
   INVALID_CYPRESS_JSON: "cypress.json is not a valid json",
   INVALID_DEFAULT_AUTH_PARAMS: "Your username and access key are required to run your tests on BrowserStack. Learn more at https://www.browserstack.com/docs/automate/cypress/authentication",

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -54,9 +54,9 @@ const cliMessages = {
         PARALLEL_DESC: "The maximum number of parallels to use to run your test suite",
         INFO: "Run your tests on BrowserStack.",
         DESC: "Path to BrowserStack config",
-        CYPRESS_DESC: "Path to cypress config file",
+        CYPRESS_DESC: "Path to Cypress config file",
         CONFIG_DEMAND: "config file is required",
-        CYPRESS_CONFIG_DEMAND: "cypress config file is required",
+        CYPRESS_CONFIG_DEMAND: "Cypress config file is required",
         BUILD_NAME: "The build name you want to use to name your test runs"
     },
     COMMON: {

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -54,7 +54,9 @@ const cliMessages = {
         PARALLEL_DESC: "The maximum number of parallels to use to run your test suite",
         INFO: "Run your tests on BrowserStack.",
         DESC: "Path to BrowserStack config",
+        CYPRESS_DESC: "Path to cypress config file",
         CONFIG_DEMAND: "config file is required",
+        CYPRESS_CONFIG_DEMAND: "cypress config file is required",
         BUILD_NAME: "The build name you want to use to name your test runs"
     },
     COMMON: {

--- a/bin/helpers/usageReporting.js
+++ b/bin/helpers/usageReporting.js
@@ -34,7 +34,7 @@ function local_cypress_version(bsConfig) {
   // 2. check version of Cypress installed globally if not present in project
 
   if (bsConfig) {
-    let version = get_version(path.join(bsConfig.run_settings.cypressProjectDir, 'node_modules', '.bin', 'cypress'));
+    let version = get_version(path.join(bsConfig.run_settings.cypress_proj_dir, 'node_modules', '.bin', 'cypress'));
     if (!version) {
       version = get_version('cypress');
     }
@@ -81,7 +81,7 @@ function cli_version_and_path(bsConfig) {
   // 2. check version of Cypress installed globally if not present in project
 
   if (bsConfig) {
-    let _path = path.join(bsConfig.run_settings.cypressProjectDir, 'node_modules', 'browserstack-cypress');
+    let _path = path.join(bsConfig.run_settings.cypress_proj_dir, 'node_modules', 'browserstack-cypress');
     let version = get_version(_path);
     if (!version) {
       version = get_version('browserstack-cypress');

--- a/bin/helpers/usageReporting.js
+++ b/bin/helpers/usageReporting.js
@@ -34,7 +34,7 @@ function local_cypress_version(bsConfig) {
   // 2. check version of Cypress installed globally if not present in project
 
   if (bsConfig) {
-    let version = get_version(path.join(bsConfig.run_settings.cypress_proj_dir, 'node_modules', '.bin', 'cypress'));
+    let version = get_version(path.join(bsConfig.run_settings.cypressProjectDir, 'node_modules', '.bin', 'cypress'));
     if (!version) {
       version = get_version('cypress');
     }
@@ -81,7 +81,7 @@ function cli_version_and_path(bsConfig) {
   // 2. check version of Cypress installed globally if not present in project
 
   if (bsConfig) {
-    let _path = path.join(bsConfig.run_settings.cypress_proj_dir, 'node_modules', 'browserstack-cypress');
+    let _path = path.join(bsConfig.run_settings.cypressProjectDir, 'node_modules', 'browserstack-cypress');
     let version = get_version(_path);
     if (!version) {
       version = get_version('browserstack-cypress');
@@ -127,7 +127,7 @@ function ci_environment() {
   }
   // CircleCI
   if (env.CI === "true" && env.CIRCLECI === "true") {
-    return "CircleCI"; 
+    return "CircleCI";
   }
   // Travis CI
   if (env.CI === "true" && env.TRAVIS === "true") {

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -95,6 +95,26 @@ exports.setBuildName = (bsConfig, args) => {
   }
 }
 
+exports.searchForOption = (option) => {
+  return (process.argv.indexOf(option) > -1);
+}
+
+exports.verifyCypressConfigFileOption = () => {
+  let ccfOptionsSet = (this.searchForOption('-ccf') || this.searchForOption('--ccf'));
+  let cypressConfigFileSet = (this.searchForOption('-cypress-config-file') || this.searchForOption('--cypress-config-file'));
+  let cypressConfigOptionsSet = (this.searchForOption('-cypressConfigFile') || this.searchForOption('--cypressConfigFile'));
+  return (ccfOptionsSet || cypressConfigFileSet || cypressConfigOptionsSet);
+}
+
+exports.setCypressConfigFilename = (bsConfig, args) => {
+  let userPassedCypessConfigFile = this.verifyCypressConfigFileOption();
+
+  if (userPassedCypessConfigFile || this.isUndefined(bsConfig.run_settings.cypress_config_file)) {
+    bsConfig.run_settings.cypress_config_filename = path.basename(args.cypressConfigFile);
+    bsConfig.run_settings.cypress_config_file = args.cypressConfigFile;
+  }
+}
+
 exports.isUndefined = value => (value === undefined || value === null);
 
 exports.isFloat = value => (Number(value) && Number(value) % 1 !== 0);

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -131,13 +131,16 @@ exports.verifyCypressConfigFileOption = () => {
 exports.setCypressConfigFilename = (bsConfig, args) => {
   let userProvidedCypessConfigFile = this.verifyCypressConfigFileOption();
 
+  bsConfig.run_settings.userProvidedCypessConfigFile = (userProvidedCypessConfigFile || (!this.isUndefined(bsConfig.run_settings.cypress_config_file)));
+
   if (userProvidedCypessConfigFile || this.isUndefined(bsConfig.run_settings.cypress_config_file)) {
-    bsConfig.run_settings.cypress_config_filename = path.basename(args.cypressConfigFile);
     bsConfig.run_settings.cypress_config_file = args.cypressConfigFile;
-    bsConfig.run_settings.userProvidedCypessConfigFile = userProvidedCypessConfigFile;
+    bsConfig.run_settings.cypress_config_filename = path.basename(args.cypressConfigFile);
+  } else if (!this.isUndefined(bsConfig.run_settings.cypress_config_file)) {
+    bsConfig.run_settings.cypress_config_filename = path.basename(bsConfig.run_settings.cypress_config_file);
   }
 
-  bsConfig.run_settings.cypressConfigFilePath = userProvidedCypessConfigFile ? bsConfig.run_settings.cypress_config_file : path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json');
+  bsConfig.run_settings.cypressConfigFilePath = bsConfig.run_settings.userProvidedCypessConfigFile ? bsConfig.run_settings.cypress_config_file : path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json');
 }
 
 exports.isUndefined = value => (value === undefined || value === null);

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -55,6 +55,9 @@ exports.getErrorCodeFromMsg = (errMsg) => {
     case Constants.validationMessages.INCORRECT_DIRECTORY_STRUCTURE:
       errorCode = "invalid_directory_structure";
       break;
+    case Constants.validationMessages.INVALID_CYPRESS_CONFIG_FILE:
+      errorCode = "invalid_cypress_config_file";
+      break;
   }
   if (
     errMsg.includes("Please use --config-file <path to browserstack.json>.")
@@ -168,7 +171,13 @@ exports.setCypressConfigFilename = (bsConfig, args) => {
     bsConfig.run_settings.cypress_config_filename = path.basename(bsConfig.run_settings.cypress_config_file);
   }
 
-  bsConfig.run_settings.cypressConfigFilePath = bsConfig.run_settings.userProvidedCypessConfigFile ? bsConfig.run_settings.cypress_config_file : path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json');
+  if (bsConfig.run_settings.userProvidedCypessConfigFile){
+    bsConfig.run_settings.cypressConfigFilePath = bsConfig.run_settings.cypress_config_file;
+    bsConfig.run_settings.cypressProjectDir = path.dirname(bsConfig.run_settings.cypress_config_file);
+  } else {
+    bsConfig.run_settings.cypressConfigFilePath = path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json');
+    bsConfig.run_settings.cypressProjectDir = bsConfig.run_settings.cypress_proj_dir;
+  }
 }
 
 // specs can be passed from bstack configuration file

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -128,6 +128,11 @@ exports.verifyCypressConfigFileOption = () => {
   return (ccfOptionsSet || cypressConfigFileSet || cypressConfigOptionsSet);
 }
 
+//  TODO: Remove when cleaningup cypress_proj_dir
+//
+// 1. Remove demand from runner.js for --ccf option.
+// 2. Remove the strict check functions: verifyCypressConfigFileOption
+// 3. Just use the args.cypressConfigFile for checking the value for cypress config file.
 exports.setCypressConfigFilename = (bsConfig, args) => {
   let userProvidedCypessConfigFile = this.verifyCypressConfigFileOption();
 

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -122,12 +122,15 @@ exports.verifyCypressConfigFileOption = () => {
 }
 
 exports.setCypressConfigFilename = (bsConfig, args) => {
-  let userPassedCypessConfigFile = this.verifyCypressConfigFileOption();
+  let userProvidedCypessConfigFile = this.verifyCypressConfigFileOption();
 
-  if (userPassedCypessConfigFile || this.isUndefined(bsConfig.run_settings.cypress_config_file)) {
+  if (userProvidedCypessConfigFile || this.isUndefined(bsConfig.run_settings.cypress_config_file)) {
     bsConfig.run_settings.cypress_config_filename = path.basename(args.cypressConfigFile);
     bsConfig.run_settings.cypress_config_file = args.cypressConfigFile;
+    bsConfig.run_settings.userProvidedCypessConfigFile = userProvidedCypessConfigFile;
   }
+
+  bsConfig.run_settings.cypressConfigFilePath = userProvidedCypessConfigFile ? bsConfig.run_settings.cypress_config_file : path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json');
 }
 
 exports.isUndefined = value => (value === undefined || value === null);

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -139,7 +139,7 @@ var argv = yargs
         'ccf': {
           alias: 'cypress-config-file',
           describe: Constants.cliMessages.RUN.CYPRESS_DESC,
-          default: 'cypress.json',
+          default: './cypress.json',
           type: 'string',
           nargs: 1,
           demand: true,

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -136,6 +136,15 @@ var argv = yargs
           demand: true,
           demand: Constants.cliMessages.RUN.CONFIG_DEMAND
         },
+        'ccf': {
+          alias: 'cypress-config-file',
+          describe: Constants.cliMessages.RUN.CYPRESS_DESC,
+          default: 'cypress.json',
+          type: 'string',
+          nargs: 1,
+          demand: true,
+          demand: Constants.cliMessages.RUN.CYPRESS_CONFIG_DEMAND
+        },
         'disable-usage-reporting': {
           default: undefined,
           description: Constants.cliMessages.COMMON.DISABLE_USAGE_REPORTING,

--- a/bin/templates/configTemplate.js
+++ b/bin/templates/configTemplate.js
@@ -52,7 +52,7 @@ module.exports = function () {
       }
     ],
     "run_settings": {
-      "cypress_proj_dir" : "/path/to/directory-that-contains-<cypress.json>-file",
+      "cypress_config_file" : "/path/to/<cypress config file>.json",
       "project_name": "project-name",
       "build_name": "build-name",
       "parallels": "Here goes the number of parallels you want to run",

--- a/test/unit/bin/commands/runs.js
+++ b/test/unit/bin/commands/runs.js
@@ -85,6 +85,7 @@ describe("runs", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       setBuildNameStub = sandbox.stub();
+      setCypressConfigFilenameStub = sandbox.stub();
       getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -116,6 +117,7 @@ describe("runs", () => {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           setBuildName: setBuildNameStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getConfigPath: getConfigPathStub,
           setLocal: setLocalStub,
           setLocalIdentifier: setLocalIdentifierStub,
@@ -165,6 +167,7 @@ describe("runs", () => {
       setAccessKeyStub = sandbox.stub();
       getConfigPathStub = sandbox.stub();
       setBuildNameStub = sandbox.stub();
+      setCypressConfigFilenameStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -196,6 +199,7 @@ describe("runs", () => {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           setBuildName: setBuildNameStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getConfigPath: getConfigPathStub,
           setLocal: setLocalStub,
@@ -255,6 +259,7 @@ describe("runs", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       setBuildNameStub = sandbox.stub();
+      setCypressConfigFilenameStub = sandbox.stub();
       getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -287,6 +292,7 @@ describe("runs", () => {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           setBuildName: setBuildNameStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getConfigPath: getConfigPathStub,
           setLocal: setLocalStub,
@@ -353,6 +359,7 @@ describe("runs", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       setBuildNameStub = sandbox.stub();
+      setCypressConfigFilenameStub = sandbox.stub();
       getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -386,6 +393,7 @@ describe("runs", () => {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           setBuildName: setBuildNameStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           getConfigPath: getConfigPathStub,
           setLocal: setLocalStub,
@@ -463,6 +471,7 @@ describe("runs", () => {
       setUsernameStub = sandbox.stub();
       setAccessKeyStub = sandbox.stub();
       setBuildNameStub = sandbox.stub();
+      setCypressConfigFilenameStub = sandbox.stub();
       getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
@@ -499,6 +508,7 @@ describe("runs", () => {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           setBuildName: setBuildNameStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           setParallels: setParallelsStub,
           getConfigPath: getConfigPathStub,

--- a/test/unit/bin/helpers/capabilityHelper.js
+++ b/test/unit/bin/helpers/capabilityHelper.js
@@ -734,6 +734,37 @@ describe("capabilityHelper.js", () => {
             fs.readFileSync.restore();
           });
       });
+
+      context("cypress config file set to false", () => {
+        beforeEach(function() {
+          readFileSpy = sinon.stub(fs, 'readFileSync');
+          jsonParseSpy = sinon.stub(JSON, 'parse');
+        });
+
+        afterEach(function() {
+          readFileSpy.restore();
+          jsonParseSpy.restore();
+        });
+
+        it("does not validate with cypress config filename set to false", () => {
+          // sinon.stub(fs, 'existsSync').returns(false);
+          bsConfig.run_settings.cypressConfigFilePath = 'false';
+          bsConfig.run_settings.cypress_config_filename = 'false';
+
+          return capabilityHelper
+            .validate(bsConfig, {})
+            .then(function (data) {
+              sinon.assert.notCalled(readFileSpy);
+              sinon.assert.notCalled(jsonParseSpy);
+            })
+            .catch((error) => {
+              chai.assert.equal(
+                error,
+                Constants.validationMessages.INCORRECT_DIRECTORY_STRUCTURE
+              );
+            });
+        })
+      });
     });
   });
 });

--- a/test/unit/bin/helpers/capabilityHelper.js
+++ b/test/unit/bin/helpers/capabilityHelper.js
@@ -783,7 +783,8 @@ describe("capabilityHelper.js", () => {
           ],
           run_settings: {
             cypress_proj_dir: "random path",
-            cypressConfigFilePath: "random path"
+            cypressConfigFilePath: "random path",
+            cypressProjectDir: "random path"
           },
         };
       });
@@ -799,7 +800,7 @@ describe("capabilityHelper.js", () => {
           .catch((error) => {
             chai.assert.equal(
               error,
-              Constants.validationMessages.CYPRESS_JSON_NOT_FOUND + "random path"
+              Constants.validationMessages.INVALID_CYPRESS_CONFIG_FILE
             );
             fs.existsSync.restore();
           });
@@ -860,6 +861,7 @@ describe("capabilityHelper.js", () => {
               error,
               Constants.validationMessages.INCORRECT_DIRECTORY_STRUCTURE
             );
+
             fs.existsSync.restore();
             fs.readFileSync.restore();
           });

--- a/test/unit/bin/helpers/capabilityHelper.js
+++ b/test/unit/bin/helpers/capabilityHelper.js
@@ -269,7 +269,8 @@ describe("capabilityHelper.js", () => {
             },
           ],
           run_settings: {
-            cypress_proj_dir: "random path"
+            cypress_proj_dir: "random path",
+            cypressConfigFilePath: "random path"
           },
         };
       });
@@ -651,7 +652,8 @@ describe("capabilityHelper.js", () => {
             },
           ],
           run_settings: {
-            cypress_proj_dir: "random path"
+            cypress_proj_dir: "random path",
+            cypressConfigFilePath: "random path"
           },
         };
       });

--- a/test/unit/bin/helpers/usageReporting.js
+++ b/test/unit/bin/helpers/usageReporting.js
@@ -340,7 +340,7 @@ describe("usageReporting", () => {
       expect(isUsageReportingEnabled()).to.be.undefined;
     });
   });
-  
+
   describe("ci_environment", () => {
     afterEach(() => {
       delete process.env.JENKINS_URL;

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -482,4 +482,126 @@ describe("utils", () => {
     });
 
   });
+
+  describe("verifyCypressConfigFileOption", () => {
+    let utilsearchForOptionCypressConfigFileStub, userOption, testOption;
+
+    beforeEach(function() {
+      utilsearchForOptionCypressConfigFileStub = sinon
+                                                    .stub(utils, 'searchForOption')
+                                                    .callsFake((...userOption) => {
+                                                      return (userOption == testOption);
+                                                    });
+    });
+
+    afterEach(function() {
+      utilsearchForOptionCypressConfigFileStub.restore();
+    });
+
+    it("-ccf user option", () => {
+      testOption = '-ccf';
+      expect(utils.verifyCypressConfigFileOption()).to.be.true;
+      sinon.assert.calledWithExactly(utilsearchForOptionCypressConfigFileStub, testOption);
+    });
+
+    it("--ccf user option", () => {
+      testOption = '--ccf';
+      expect(utils.verifyCypressConfigFileOption()).to.be.true;
+      sinon.assert.calledWithExactly(utilsearchForOptionCypressConfigFileStub, testOption);
+    });
+
+    it("-cypress-config-file user option", () => {
+      testOption = '-cypress-config-file';
+      expect(utils.verifyCypressConfigFileOption()).to.be.true;
+      sinon.assert.calledWithExactly(utilsearchForOptionCypressConfigFileStub, testOption);
+    });
+
+    it("--cypress-config-file user option", () => {
+      testOption = '--cypress-config-file';
+      expect(utils.verifyCypressConfigFileOption()).to.be.true;
+      sinon.assert.calledWithExactly(utilsearchForOptionCypressConfigFileStub, testOption);
+    });
+
+    it("-cypressConfigFile user option", () => {
+      testOption = '-cypressConfigFile';
+      expect(utils.verifyCypressConfigFileOption()).to.be.true;
+      sinon.assert.calledWithExactly(utilsearchForOptionCypressConfigFileStub, testOption);
+    });
+
+    it("--cypressConfigFile user option", () => {
+      testOption = '--cypressConfigFile';
+      expect(utils.verifyCypressConfigFileOption()).to.be.true;
+      sinon.assert.calledWithExactly(utilsearchForOptionCypressConfigFileStub, testOption);
+    });
+  });
+
+  describe("setCypressConfigFilename", () => {
+    let verifyCypressConfigFileOptionStub,
+        ccfBool, args, bsConfig, cypress_config_file;
+
+    beforeEach(function() {
+      verifyCypressConfigFileOptionStub = sinon
+                                            .stub(utils, 'verifyCypressConfigFileOption')
+                                            .callsFake(() => ccfBool);
+
+      args = {
+        cypressConfigFile: "args_cypress_config_file"
+      };
+    });
+
+    it("has user provided ccf flag", () => {
+      ccfBool = true;
+
+      bsConfig = {
+        run_settings: {
+          cypress_config_file: "run_settings_cypress_config_file"
+        }
+      };
+
+      utils.setCypressConfigFilename(bsConfig, args);
+
+      expect(bsConfig.run_settings.cypress_config_file).to.be.eq(args.cypressConfigFile);
+      expect(bsConfig.run_settings.cypress_config_filename).to.be.eq(path.basename(args.cypressConfigFile));
+      expect(bsConfig.run_settings.userProvidedCypessConfigFile).to.be.true;
+      expect(bsConfig.run_settings.cypressConfigFilePath).to.be.eq(bsConfig.run_settings.cypress_config_file);
+    });
+
+    it("does not have user provided ccf flag, sets the value from cypress_proj_dir", () => {
+      ccfBool = false;
+
+      bsConfig = {
+        run_settings: {
+          cypress_proj_dir: "cypress_proj_dir"
+        }
+      };
+
+      utils.setCypressConfigFilename(bsConfig, args);
+
+      expect(bsConfig.run_settings.cypress_config_file).to.be.eq(args.cypressConfigFile);
+      expect(bsConfig.run_settings.cypress_config_filename).to.be.eq(path.basename(args.cypressConfigFile));
+      expect(bsConfig.run_settings.userProvidedCypessConfigFile).to.be.false;
+      expect(bsConfig.run_settings.cypressConfigFilePath).to.be.eq(path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json'));
+    });
+
+    it("does not have user provided ccf flag, sets from config file", () => {
+      cypress_config_file = "run_settings_cypress_config_file";
+      ccfBool = false;
+      bsConfig = {
+        run_settings: {
+          cypress_config_file: cypress_config_file
+        }
+      };
+
+      utils.setCypressConfigFilename(bsConfig, args);
+
+      expect(bsConfig.run_settings.cypress_config_file).to.be.eq(cypress_config_file);
+      expect(bsConfig.run_settings.cypress_config_filename).to.be.eq(path.basename(cypress_config_file));
+      expect(bsConfig.run_settings.userProvidedCypessConfigFile).to.be.true;
+      expect(bsConfig.run_settings.cypressConfigFilePath).to.be.eq(bsConfig.run_settings.cypress_config_file);
+    });
+
+    afterEach(function() {
+      verifyCypressConfigFileOptionStub.restore();
+    })
+  });
 });

--- a/test/unit/support/fixtures/testObjects.js
+++ b/test/unit/support/fixtures/testObjects.js
@@ -4,7 +4,9 @@ const sampleBsConfig = {
     access_key: "random-access-key",
   },
   run_settings: {
-    cypress_proj_dir: "random path"
+    cypress_proj_dir: "random path",
+    cypressConfigFilePath: "random path",
+    cypressProjectDir: "random path"
   }
 };
 


### PR DESCRIPTION
PR Implements following:

- Enable --ccf/--cypress-config-file options with `./cypress.json` as default
- The option provided enables user to set their preferred cypress.json config file or disable it altogether.
- Current implementation back port to `cypress_proj_dir` if both the values not set by users explicitly to avoid breaking the current flow.

Usage:

Absolute path:

    browserstack-cypress run --ccf /path/to/my.cypress.json

Relative path:

    browserstack-cypress run --ccf ./my.cypress.json