### PR TITLE
Sync cli part 4 messaging

### DIFF
--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -1,9 +1,13 @@
+const syncCLI = {
+  FAILED_SPEC_DETAILS_COL_HEADER: ['Spec', 'Status', 'Browser', 'BrowserStack Session ID']
+};
+
 const userMessages = {
     BUILD_FAILED: "Build creation failed.",
     BUILD_CREATED: "Build created",
     BUILD_INFO_FAILED: "Failed to get build info.",
     BUILD_STOP_FAILED: "Failed to stop build.",
-    BUILD_REPORT_MESDSAGE: "See the entire build report here:",
+    BUILD_REPORT_MESSAGE: "See the entire build report here:",
     ZIP_UPLOADER_NOT_REACHABLE: "Could not reach to zip uploader.",
     ZIP_UPLOAD_FAILED: "Zip Upload failed.",
     CONFIG_FILE_CREATED: "BrowserStack Config File created, you can now run browserstack-cypress --config-file run",
@@ -94,6 +98,7 @@ const allowedFileTypes = ['js', 'json', 'txt', 'ts', 'feature', 'features', 'pdf
 const filesToIgnoreWhileUploading = ['node_modules/**', 'package-lock.json', 'package.json', 'browserstack-package.json', 'tests.zip', 'cypress.json']
 
 module.exports = Object.freeze({
+  syncCLI,
   userMessages,
   cliMessages,
   validationMessages,

--- a/bin/helpers/sync/failedSpecsDetails.js
+++ b/bin/helpers/sync/failedSpecsDetails.js
@@ -1,3 +1,6 @@
+const { table, getBorderCharacters } = require('table'),
+      chalk = require('chalk');
+
 /**
  *
  * @param {Array.<{specName: string, status: string, combination: string, sessionId: string}>} data

--- a/bin/helpers/sync/failedSpecsDetails.js
+++ b/bin/helpers/sync/failedSpecsDetails.js
@@ -1,0 +1,64 @@
+/**
+ *
+ * @param {Array.<{specName: string, status: string, combination: string, sessionId: string}>} data
+ * @returns {Promise.resolve || Promise.reject}
+ */
+// Example:
+// [
+//   {specName: 'spec1.failed.js', status: 'Failed', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'},
+//   {specName: 'spec2.name.js', status: 'Skipped', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'},
+//   {specName: 'spec3.network.js', status: 'Failed', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'},
+//   {specName: 'spec6.utils.js', status: 'Failed', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'},
+//   {specName: 'spec8.alias.js', status: 'Skipped', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'}
+// ]
+//
+let failedSpecsDetails = (data) => {
+  return new Promise((resolve, reject) => {
+    if (data.length === 0) resolve(0); // return if no failed/skipped tests.
+
+    let failedSpecs = false;
+    let specResultHeader = Constants.syncCLI.FAILED_SPEC_DETAILS_COL_HEADER.map((col) => {
+      return chalk.blueBright(col);
+    });
+
+    let specData = [specResultHeader]; // 2-D array
+
+    data.forEach((spec) => {
+      if (spec.status && spec.status.toLowerCase() === 'failed' && !failedSpecs)
+        failedSpecs = true;
+
+      let specStatus = (spec.status && spec.status.toLowerCase() === 'failed') ?
+                          chalk.red(spec.status) : chalk.yellow(spec.status);
+      specData.push([spec.specName, specStatus, spec.combination, spec.sessionId]);
+    });
+
+    let config = {
+      border: getBorderCharacters('ramac'),
+      columns: {
+        0: { alignment: 'left' },
+        1: { alignment: 'left' },
+        2: { alignment: 'left' },
+        3: { alignment: 'left' },
+      },
+      /**
+      * @typedef {function} drawHorizontalLine
+      * @param {number} index
+      * @param {number} size
+      * @return {boolean}
+      */
+      drawHorizontalLine: (index, size) => {
+        return (index === 0 || index === 1 ||  index === size);
+      }
+    }
+
+    let result = table(specData, config);
+
+    logger.info('Failed / skipped test report');
+    logger.info(result);
+
+    if (failedSpecs) reject(1); // specs failed, send exitCode as 1
+    resolve(0); // No Specs failed, maybe skipped, but not failed, send exitCode as 0
+  });
+}
+
+exports.failedSpecsDetails = failedSpecsDetails;

--- a/bin/helpers/sync/failedSpecsDetails.js
+++ b/bin/helpers/sync/failedSpecsDetails.js
@@ -1,5 +1,7 @@
-const { table, getBorderCharacters } = require('table'),
-      chalk = require('chalk');
+const tablePrinter = require('table'), // { table, getBorderCharacters }
+      chalk = require('chalk'),
+      Constants = require("../constants"),
+      logger = require("../logger").syncCliLogger;
 
 /**
  *
@@ -36,7 +38,7 @@ let failedSpecsDetails = (data) => {
     });
 
     let config = {
-      border: getBorderCharacters('ramac'),
+      border: tablePrinter.getBorderCharacters('ramac'),
       columns: {
         0: { alignment: 'left' },
         1: { alignment: 'left' },
@@ -54,7 +56,7 @@ let failedSpecsDetails = (data) => {
       }
     }
 
-    let result = table(specData, config);
+    let result = tablePrinter.table(specData, config);
 
     logger.info('Failed / skipped test report');
     logger.info(result);

--- a/bin/helpers/syncRunner.js
+++ b/bin/helpers/syncRunner.js
@@ -4,6 +4,7 @@ const Config = require("./config"),
   Constants = require("./constants"),
   utils = require("./utils"),
   request = require('request'),
+  specDetails = require('./sync/failedSpecsDetails'),
   { table, getBorderCharacters } = require('table'),
   chalk = require('chalk');
 
@@ -13,7 +14,7 @@ exports.pollBuildStatus = (bsConfig, buildId) => {
   }).then((data) => {
     printSpecsRunSummary();
   }).then((data) => {
-    printFailedSpecsDetails(data);
+    return specDetails.failedSpecsDetails(data);
   }).then((successExitCode) => {
     return resolveExitCode(successExitCode); // exit code 0
   }).catch((nonZeroExitCode) => {
@@ -34,68 +35,6 @@ let printSpecsStatus = () => {
 
 let printSpecsRunSummary = () => {
 
-};
-
-/**
- *
- * @param {Array.<{specName: string, status: string, combination: string, sessionId: string}>} data
- * @returns {Promise.resolve || Promise.reject}
- */
-// Example:
-// [
-//   {specName: 'spec1.failed.js', status: 'Failed', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'},
-//   {specName: 'spec2.name.js', status: 'Skipped', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'},
-//   {specName: 'spec3.network.js', status: 'Failed', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'},
-//   {specName: 'spec6.utils.js', status: 'Failed', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'},
-//   {specName: 'spec8.alias.js', status: 'Skipped', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'}
-// ]
-let printFailedSpecsDetails = (data) => {
-  return new Promise((resolve, reject) => {
-    if (data.length === 0) resolve(0); // return if no failed/skipped tests.
-
-    let failedSpecs = false;
-    let specResultHeader = Constants.syncCLI.FAILED_SPEC_DETAILS_COL_HEADER.map((col) => {
-      return chalk.blueBright(col);
-    });
-
-    let specData = [specResultHeader]; // 2-D array
-
-    data.forEach((spec) => {
-      if (spec.status && spec.status.toLowerCase() === 'failed' && !failedSpecs)
-        failedSpecs = true;
-
-      let specStatus = (spec.status && spec.status.toLowerCase() === 'failed') ?
-                          chalk.red(spec.status) : chalk.yellow(spec.status);
-      specData.push([spec.specName, specStatus, spec.combination, spec.sessionId]);
-    });
-
-    let config = {
-      border: getBorderCharacters('ramac'),
-      columns: {
-        0: { alignment: 'left' },
-        1: { alignment: 'left' },
-        2: { alignment: 'left' },
-        3: { alignment: 'left' },
-      },
-      /**
-      * @typedef {function} drawHorizontalLine
-      * @param {number} index
-      * @param {number} size
-      * @return {boolean}
-      */
-      drawHorizontalLine: (index, size) => {
-        return (index === 0 || index === 1 ||  index === size);
-      }
-    }
-
-    let result = table(specData, config);
-
-    logger.info('Failed / skipped test report');
-    logger.info(result);
-
-    if (failedSpecs) reject(1); // specs failed, send exitCode as 1
-    resolve(0); // No Specs failed, maybe skipped, but not failed, send exitCode as 0
-  });
 };
 
 let resolveExitCode = (exitCode) => {

--- a/bin/helpers/syncRunner.js
+++ b/bin/helpers/syncRunner.js
@@ -1,9 +1,11 @@
 'use strict';
-const config = require("./config"),
+const Config = require("./config"),
   logger = require("./logger").syncCliLogger,
   Constants = require("./constants"),
   utils = require("./utils"),
-  request = require('request');
+  request = require('request'),
+  { table, getBorderCharacters } = require('table'),
+  chalk = require('chalk');
 
 exports.pollBuildStatus = (bsConfig, buildId) => {
   logBuildDetails().then((data) => {
@@ -11,15 +13,14 @@ exports.pollBuildStatus = (bsConfig, buildId) => {
   }).then((data) => {
     printSpecsRunSummary();
   }).then((data) => {
-    printFailedSpecsDetails();
-  }).then((data) => {
-    printBuildDashboardLink(buildId);
-  }).then((data) => {
-    // success case!
-    return 0; // exit code 0
-  }).catch((err) => {
-    // failed case!
-    return 1; // exit code 1
+    printFailedSpecsDetails(data);
+  }).then((successExitCode) => {
+    return resolveExitCode(successExitCode); // exit code 0
+  }).catch((nonZeroExitCode) => {
+    return resolveExitCode(nonZeroExitCode); // exit code 1
+  }).finally(() => {
+    logger.info(Constants.userMessages.BUILD_REPORT_MESSAGE);
+    logger.info(`${Config.dashboardUrl}${buildId}`);
   });
 };
 
@@ -35,13 +36,68 @@ let printSpecsRunSummary = () => {
 
 };
 
-let printFailedSpecsDetails = () => {
+/**
+ *
+ * @param {Array.<{specName: string, status: string, combination: string, sessionId: string}>} data
+ * @returns {Promise.resolve || Promise.reject}
+ */
+// Example:
+// [
+//   {specName: 'spec1.failed.js', status: 'Failed', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'},
+//   {specName: 'spec2.name.js', status: 'Skipped', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'},
+//   {specName: 'spec3.network.js', status: 'Failed', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'},
+//   {specName: 'spec6.utils.js', status: 'Failed', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'},
+//   {specName: 'spec8.alias.js', status: 'Skipped', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'}
+// ]
+let printFailedSpecsDetails = (data) => {
+  return new Promise((resolve, reject) => {
+    if (data.length === 0) resolve(0); // return if no failed/skipped tests.
 
+    let failedSpecs = false;
+    let specResultHeader = Constants.syncCLI.FAILED_SPEC_DETAILS_COL_HEADER.map((col) => {
+      return chalk.blueBright(col);
+    });
+
+    let specData = [specResultHeader]; // 2-D array
+
+    data.forEach((spec) => {
+      if (spec.status && spec.status.toLowerCase() === 'failed' && !failedSpecs)
+        failedSpecs = true;
+
+      let specStatus = (spec.status && spec.status.toLowerCase() === 'failed') ?
+                          chalk.red(spec.status) : chalk.yellow(spec.status);
+      specData.push([spec.specName, specStatus, spec.combination, spec.sessionId]);
+    });
+
+    let config = {
+      border: getBorderCharacters('ramac'),
+      columns: {
+        0: { alignment: 'center' },
+        1: { alignment: 'center' },
+        2: { alignment: 'center' },
+        3: { alignment: 'center' },
+      },
+      /**
+      * @typedef {function} drawHorizontalLine
+      * @param {number} index
+      * @param {number} size
+      * @return {boolean}
+      */
+      drawHorizontalLine: (index, size) => {
+        return (index === 0 || index === 1 ||  index === size);
+      }
+    }
+
+    let result = table(specData, config);
+
+    logger.info('Failed / skipped test report');
+    logger.info(result);
+
+    if (failedSpecs) reject(1); // specs failed, send exitCode as 1
+    resolve(0); // No Specs failed, maybe skipped, but not failed, send exitCode as 0
+  });
 };
 
-let printBuildDashboardLink = (buildId) => {
-  new Promise((resolve, reject) => {
-    logger.info(Constants.userMessages.BUILD_REPORT_MESSAGE);
-    logger.info(`${config.dashboardUrl}${buildId}`);
-  });
+let resolveExitCode = (exitCode) => {
+  return new Promise((resolve, _reject) => { resolve(exitCode) });
 };

--- a/bin/helpers/syncRunner.js
+++ b/bin/helpers/syncRunner.js
@@ -72,10 +72,10 @@ let printFailedSpecsDetails = (data) => {
     let config = {
       border: getBorderCharacters('ramac'),
       columns: {
-        0: { alignment: 'center' },
-        1: { alignment: 'center' },
-        2: { alignment: 'center' },
-        3: { alignment: 'center' },
+        0: { alignment: 'left' },
+        1: { alignment: 'left' },
+        2: { alignment: 'left' },
+        3: { alignment: 'left' },
       },
       /**
       * @typedef {function} drawHorizontalLine

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "archiver": "^3.1.1",
+    "chalk": "^4.1.0",
     "fs-extra": "^8.1.0",
     "mkdirp": "^1.0.3",
     "request": "^2.88.0",

--- a/test/unit/bin/helpers/sync/failedSpecDetails.js
+++ b/test/unit/bin/helpers/sync/failedSpecDetails.js
@@ -1,18 +1,17 @@
 'use strict';
 const chai = require("chai"),
   expect = chai.expect,
-  sinon = require('sinon'),
-  chaiAsPromised = require("chai-as-promised"),
-  fs = require('fs');
+  chaiAsPromised = require("chai-as-promised");
 
+chai.use(chaiAsPromised);
 const specDetails = require('../../../../../bin/helpers/sync/failedSpecsDetails');
 
 describe("failedSpecsDetails", () => {
   context("data is empty", () => {
     let data = [];
     it('returns 0 exit code', () => {
-      specDetails.failedSpecsDetails(data).then((status) => {
-        chai.assert.equal(data, 0);
+      return specDetails.failedSpecsDetails(data).then((status) => {
+        expect(status).to.equal(0);
       });
     });
   });
@@ -23,8 +22,24 @@ describe("failedSpecsDetails", () => {
     ];
 
     it("returns 0 exit code", () => {
-      specDetails.failedSpecsDetails(data).then((status) => {
-        chai.assert.equal(data, 0);
+      return specDetails.failedSpecsDetails(data).then((status) => {
+        expect(status).to.equal(0);
+      });
+    });
+  });
+
+  context("data has failed specs", () => {
+    let data = [
+      {specName: 'spec2.name.js', status: 'Failed', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'}
+    ];
+
+    it("returns 1 exit code", () => {
+      return specDetails.failedSpecsDetails(data)
+        .then((status) => {
+          chai.assert.equal(status, 1);
+          expect(status).to.equal(1);
+        }).catch((status) => {
+          expect(status).to.equal(1);
       });
     });
   });

--- a/test/unit/bin/helpers/sync/failedSpecDetails.js
+++ b/test/unit/bin/helpers/sync/failedSpecDetails.js
@@ -1,0 +1,31 @@
+'use strict';
+const chai = require("chai"),
+  expect = chai.expect,
+  sinon = require('sinon'),
+  chaiAsPromised = require("chai-as-promised"),
+  fs = require('fs');
+
+const specDetails = require('../../../../../bin/helpers/sync/failedSpecsDetails');
+
+describe("failedSpecsDetails", () => {
+  context("data is empty", () => {
+    let data = [];
+    it('returns 0 exit code', () => {
+      specDetails.failedSpecsDetails(data).then((status) => {
+        chai.assert.equal(data, 0);
+      });
+    });
+  });
+
+  context("data does not have failed specs", () => {
+    let data = [
+      {specName: 'spec2.name.js', status: 'Skipped', combination: 'Win 10 / Chrome 78', sessionId: '3d3rdf3r...'}
+    ];
+
+    it("returns 0 exit code", () => {
+      specDetails.failedSpecsDetails(data).then((status) => {
+        chai.assert.equal(data, 0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Print an ASCII table with Failed / Skipped specs in it.
- Details include spec name, status, combination, and session id in the order.
- The status and header are color printed for better readability.
- Handle the resolve and reject which bubble up the exit code to the main run.
- process will now exit as zero or non zero code.
- Fixed typo in constant.

Below is the output:

<img width="576" alt="Screenshot 2020-09-25 at 8 44 06 PM" src="https://user-images.githubusercontent.com/672793/94284358-df3d2300-ff6f-11ea-9cc2-b22ea36236ba.png">
