### PR TITLE
Add latest-n to template

### DIFF
--- a/bin/templates/configTemplate.js
+++ b/bin/templates/configTemplate.js
@@ -8,47 +8,47 @@ module.exports = function () {
       {
         "browser": "chrome",
         "os": "Windows 10",
-        "versions": ["latest", "latest-1"]
+        "versions": ["latest", "latest-1", "74"]
       },
       {
         "browser": "firefox",
         "os": "Windows 10",
-        "versions": ["latest", "latest-1"]
+        "versions": ["latest", "latest-1", "74"]
       },
       {
         "browser": "edge",
         "os": "Windows 10",
-        "versions": ["latest", "latest-1"]
+        "versions": ["latest", "latest-1", "80"]
       },
       {
         "browser": "chrome",
         "os": "OS X Mojave",
-        "versions": ["latest", "latest-1"]
+        "versions": ["latest", "latest-1", "74"]
       },
       {
         "browser": "firefox",
         "os": "OS X Mojave",
-        "versions": ["latest", "latest-1"]
+        "versions": ["latest", "latest-1", "74"]
       },
       {
         "browser": "edge",
         "os": "OS X Mojave",
-        "versions": ["latest", "latest-1"]
+        "versions": ["latest", "latest-1", "80"]
       },
       {
         "browser": "chrome",
         "os": "OS X Catalina",
-        "versions": ["latest", "latest-1"]
+        "versions": ["latest", "latest-1", "74"]
       },
       {
         "browser": "firefox",
         "os": "OS X Catalina",
-        "versions": ["latest", "latest-1"]
+        "versions": ["latest", "latest-1", "74"]
       },
       {
         "browser": "edge",
         "os": "OS X Catalina",
-        "versions": ["latest", "latest-1"]
+        "versions": ["latest", "latest-1", "80"]
       }
     ],
     "run_settings": {

--- a/bin/templates/configTemplate.js
+++ b/bin/templates/configTemplate.js
@@ -8,47 +8,47 @@ module.exports = function () {
       {
         "browser": "chrome",
         "os": "Windows 10",
-        "versions": ["78", "77"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "firefox",
         "os": "Windows 10",
-        "versions": ["74", "75"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "edge",
         "os": "Windows 10",
-        "versions": ["80", "81"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "chrome",
         "os": "OS X Mojave",
-        "versions": ["78", "77"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "firefox",
         "os": "OS X Mojave",
-        "versions": ["74", "75"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "edge",
         "os": "OS X Mojave",
-        "versions": ["80", "81"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "chrome",
         "os": "OS X Catalina",
-        "versions": ["78", "77"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "firefox",
         "os": "OS X Catalina",
-        "versions": ["74", "75"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "edge",
         "os": "OS X Catalina",
-        "versions": ["80", "81"]
+        "versions": ["latest", "latest-1"]
       }
     ],
     "run_settings": {

--- a/bin/templates/configTemplate.js
+++ b/bin/templates/configTemplate.js
@@ -8,47 +8,47 @@ module.exports = function () {
       {
         "browser": "chrome",
         "os": "Windows 10",
-        "versions": ["latest", "latest-1", "74"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "firefox",
         "os": "Windows 10",
-        "versions": ["latest", "latest-1", "74"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "edge",
         "os": "Windows 10",
-        "versions": ["latest", "latest-1", "80"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "chrome",
         "os": "OS X Mojave",
-        "versions": ["latest", "latest-1", "74"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "firefox",
         "os": "OS X Mojave",
-        "versions": ["latest", "latest-1", "74"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "edge",
         "os": "OS X Mojave",
-        "versions": ["latest", "latest-1", "80"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "chrome",
         "os": "OS X Catalina",
-        "versions": ["latest", "latest-1", "74"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "firefox",
         "os": "OS X Catalina",
-        "versions": ["latest", "latest-1", "74"]
+        "versions": ["latest", "latest-1"]
       },
       {
         "browser": "edge",
         "os": "OS X Catalina",
-        "versions": ["latest", "latest-1", "80"]
+        "versions": ["latest", "latest-1"]
       }
     ],
     "run_settings": {


### PR DESCRIPTION
Instead of hardcoding browser version in the template, using the latest-n option to specify the browser versions.