### PR TITLE
Adding the patch version in user-agent and fixing the node_env issue

### DIFF
--- a/bin/helpers/config.js
+++ b/bin/helpers/config.js
@@ -1,6 +1,6 @@
 var config = require('./config.json');
 
-config.env = process.env.NODE_ENV || "production";
+config.env = process.env.BSTACK_CYPRESS_NODE_ENV || "production";
 
 if(config.env !== "production") {
   // load config based on env

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -219,7 +219,7 @@ exports.isParallelValid = (value) => {
 }
 
 exports.getUserAgent = () => {
-  return `BStack-Cypress-CLI/1.5.0 (${os.arch()}/${os.platform()}/${os.release()})`;
+  return `BStack-Cypress-CLI/1.5.1 (${os.arch()}/${os.platform()}/${os.release()})`;
 };
 
 exports.isAbsolute = (configPath) => {


### PR DESCRIPTION
- Replacing NODE_ENV with BSTACK_CYPRESS_NODE_ENV so that users do not have conflict with the setup.
- Updated the userAgent to the patch version.