### PR TITLE
Missing auth Hash causes exception in browserstack-cypress cli

### DIFF
--- a/bin/commands/info.js
+++ b/bin/commands/info.js
@@ -10,6 +10,9 @@ module.exports = function info(args) {
   let bsConfigPath = utils.getConfigPath(args.cf);
 
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
+    // setting defaultAuthHash to {} if not present and set via env variables or via args.
+    utils.defaultAuthHash(bsConfig, args);
+    
     // accept the username from command line if provided
     utils.setUsername(bsConfig, args);
 
@@ -30,7 +33,7 @@ module.exports = function info(args) {
         password: bsConfig.auth.access_key,
       },
       headers: {
-        "User-Agent": utils.getUserAgent(),
+        'User-Agent': utils.getUserAgent(),
       },
     };
 
@@ -55,7 +58,7 @@ module.exports = function info(args) {
 
         if (resp.statusCode == 299) {
           messageType = Constants.messageTypes.INFO;
-          errorCode = "api_deprecated";
+          errorCode = 'api_deprecated';
 
           if (build) {
             message = build.message;
@@ -66,14 +69,14 @@ module.exports = function info(args) {
           }
         } else if (resp.statusCode != 200) {
           messageType = Constants.messageTypes.ERROR;
-          errorCode = "api_failed_build_info";
+          errorCode = 'api_failed_build_info';
 
           if (build) {
             message = `${
               Constants.userMessages.BUILD_INFO_FAILED
             } with error: \n${JSON.stringify(build, null, 2)}`;
             logger.error(message);
-            if (build.message === "Unauthorized") errorCode = "api_auth_failed";
+            if (build.message === 'Unauthorized') errorCode = 'api_auth_failed';
           } else {
             message = Constants.userMessages.BUILD_INFO_FAILED;
             logger.error(message);
@@ -89,7 +92,7 @@ module.exports = function info(args) {
         }
       }
       utils.sendUsageReport(bsConfig, args, message, messageType, errorCode);
-    })
+    });
   }).catch(function (err) {
     logger.error(err);
     utils.setUsageReportingFlag(null, args.disableUsageReporting);

--- a/bin/commands/info.js
+++ b/bin/commands/info.js
@@ -10,8 +10,8 @@ module.exports = function info(args) {
   let bsConfigPath = utils.getConfigPath(args.cf);
 
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
-    // setting defaultAuthHash to {} if not present and set via env variables or via args.
-    utils.defaultAuthHash(bsConfig, args);
+    // setting setDefaultAuthHash to {} if not present and set via env variables or via args.
+    utils.setDefaultAuthHash(bsConfig, args);
     
     // accept the username from command line if provided
     utils.setUsername(bsConfig, args);

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -17,6 +17,9 @@ module.exports = function run(args) {
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
     utils.setUsageReportingFlag(bsConfig, args.disableUsageReporting);
 
+    // setting defaultAuthHash to {} if not present and set via env variables or via args.
+    utils.defaultAuthHash(bsConfig,args);
+
     // accept the username from command line or env variable if provided
     utils.setUsername(bsConfig, args);
 

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -17,8 +17,8 @@ module.exports = function run(args) {
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
     utils.setUsageReportingFlag(bsConfig, args.disableUsageReporting);
 
-    // setting defaultAuthHash to {} if not present and set via env variables or via args.
-    utils.defaultAuthHash(bsConfig,args);
+    // setting setDefaultAuthHash to {} if not present and set via env variables or via args.
+    utils.setDefaultAuthHash(bsConfig,args);
 
     // accept the username from command line or env variable if provided
     utils.setUsername(bsConfig, args);

--- a/bin/commands/stop.js
+++ b/bin/commands/stop.js
@@ -10,6 +10,9 @@ module.exports = function stop(args) {
   let bsConfigPath = utils.getConfigPath(args.cf);
 
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
+    // setting defaultAuthHash to {} if not present and set via env variables or via args.
+    utils.defaultAuthHash(bsConfig, args);
+    
     // accept the username from command line if provided
     utils.setUsername(bsConfig, args);
 
@@ -30,7 +33,7 @@ module.exports = function stop(args) {
         password: bsConfig.auth.access_key,
       },
       headers: {
-        "User-Agent": utils.getUserAgent(),
+        'User-Agent': utils.getUserAgent(),
       },
     };
 
@@ -46,16 +49,16 @@ module.exports = function stop(args) {
 
         logger.info(message);
       } else {
-        let build = null
+        let build = null;
         try {
-          build = JSON.parse(body)
+          build = JSON.parse(body);
         } catch (error) {
-          build = null
+          build = null;
         }
 
         if (resp.statusCode == 299) {
           messageType = Constants.messageTypes.INFO;
-          errorCode = "api_deprecated";
+          errorCode = 'api_deprecated';
 
           if (build) {
             message = build.message;
@@ -66,14 +69,14 @@ module.exports = function stop(args) {
           }
         } else if (resp.statusCode != 200) {
           messageType = Constants.messageTypes.ERROR;
-          errorCode = "api_failed_build_stop";
+          errorCode = 'api_failed_build_stop';
 
           if (build) {
             message = `${
               Constants.userMessages.BUILD_STOP_FAILED
             } with error: \n${JSON.stringify(build, null, 2)}`;
             logger.error(message);
-            if (build.message === "Unauthorized") errorCode = "api_auth_failed";
+            if (build.message === 'Unauthorized') errorCode = 'api_auth_failed';
           } else {
             message = Constants.userMessages.BUILD_STOP_FAILED;
             logger.error(message);
@@ -85,7 +88,7 @@ module.exports = function stop(args) {
         }
       }
       utils.sendUsageReport(bsConfig, args, message, messageType, errorCode);
-    })
+    });
   }).catch(function (err) {
     logger.error(err);
     utils.setUsageReportingFlag(null, args.disableUsageReporting);

--- a/bin/commands/stop.js
+++ b/bin/commands/stop.js
@@ -10,8 +10,8 @@ module.exports = function stop(args) {
   let bsConfigPath = utils.getConfigPath(args.cf);
 
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
-    // setting defaultAuthHash to {} if not present and set via env variables or via args.
-    utils.defaultAuthHash(bsConfig, args);
+    // setting setDefaultAuthHash to {} if not present and set via env variables or via args.
+    utils.setDefaultAuthHash(bsConfig, args);
     
     // accept the username from command line if provided
     utils.setUsername(bsConfig, args);

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -116,6 +116,9 @@ exports.setParallels = (bsConfig, args) => {
 };
 
 exports.setUsername = (bsConfig, args) => {
+  if(this.isUndefined(bsConfig["auth"])){
+    bsConfig["auth"] = {};
+  }
   if (!this.isUndefined(args.username)) {
     bsConfig["auth"]["username"] = args.username;
   } else if (!this.isUndefined(process.env.BROWSERSTACK_USERNAME)) {

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -115,10 +115,17 @@ exports.setParallels = (bsConfig, args) => {
   }
 };
 
-exports.setUsername = (bsConfig, args) => {
-  if (this.isUndefined(bsConfig['auth']) && (!this.isUndefined(args.username) || !this.isUndefined(process.env.BROWSERSTACK_USERNAME))) {
+exports.defaultAuthHash = (bsConfig, args) => {
+  if (
+    this.isUndefined(bsConfig['auth']) &&
+    (!this.isUndefined(args.username) ||
+      !this.isUndefined(process.env.BROWSERSTACK_USERNAME))
+  ) {
     bsConfig['auth'] = {};
   }
+}
+
+exports.setUsername = (bsConfig, args) => {
   if (!this.isUndefined(args.username)) {
     bsConfig["auth"]["username"] = args.username;
   } else if (!this.isUndefined(process.env.BROWSERSTACK_USERNAME)) {

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -116,8 +116,8 @@ exports.setParallels = (bsConfig, args) => {
 };
 
 exports.setUsername = (bsConfig, args) => {
-  if(this.isUndefined(bsConfig["auth"])){
-    bsConfig["auth"] = {};
+  if (this.isUndefined(bsConfig['auth']) && (!this.isUndefined(args.username) || !this.isUndefined(process.env.BROWSERSTACK_USERNAME))) {
+    bsConfig['auth'] = {};
   }
   if (!this.isUndefined(args.username)) {
     bsConfig["auth"]["username"] = args.username;

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -115,7 +115,7 @@ exports.setParallels = (bsConfig, args) => {
   }
 };
 
-exports.defaultAuthHash = (bsConfig, args) => {
+exports.setDefaultAuthHash = (bsConfig, args) => {
   if (
     this.isUndefined(bsConfig['auth']) &&
     (!this.isUndefined(args.username) ||

--- a/test/unit/bin/commands/info.js
+++ b/test/unit/bin/commands/info.js
@@ -33,6 +33,7 @@ describe("buildInfo", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
+      defaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -47,8 +48,8 @@ describe("buildInfo", () => {
 
       let requestStub = sandbox.stub(request, "get").yields(null, { statusCode: 299 }, null);
 
-      const info = proxyquire("../../../../bin/commands/info", {
-        "../helpers/utils": {
+      const info = proxyquire('../../../../bin/commands/info', {
+        '../helpers/utils': {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
@@ -57,9 +58,10 @@ describe("buildInfo", () => {
           setUsageReportingFlag: setUsageReportingFlagStub,
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
-        request: { get: requestStub },
+        request: {get: requestStub},
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -84,8 +86,8 @@ describe("buildInfo", () => {
         .stub(request, "get")
         .yields(null, { statusCode: 299 }, JSON.stringify(body));
 
-      const info = proxyquire("../../../../bin/commands/info", {
-        "../helpers/utils": {
+      const info = proxyquire('../../../../bin/commands/info', {
+        '../helpers/utils': {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
@@ -94,9 +96,10 @@ describe("buildInfo", () => {
           setUsageReportingFlag: setUsageReportingFlagStub,
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
-        request: { get: requestStub },
+        request: {get: requestStub},
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -128,6 +131,7 @@ describe("buildInfo", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
+      defaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -144,8 +148,8 @@ describe("buildInfo", () => {
         .stub(request, "get")
         .yields(null, { statusCode: 400 }, null);
 
-      const info = proxyquire("../../../../bin/commands/info", {
-        "../helpers/utils": {
+      const info = proxyquire('../../../../bin/commands/info', {
+        '../helpers/utils': {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
@@ -154,9 +158,10 @@ describe("buildInfo", () => {
           setUsageReportingFlag: setUsageReportingFlagStub,
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
-        request: { get: requestStub },
+        request: {get: requestStub},
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -198,6 +203,7 @@ describe("buildInfo", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
         request: {get: requestStub},
       });
@@ -236,6 +242,7 @@ describe("buildInfo", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
         request: {get: requestStub},
       });
@@ -271,6 +278,7 @@ describe("buildInfo", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
+      defaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -296,6 +304,7 @@ describe("buildInfo", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
         request: {get: requestStub},
       });
@@ -329,6 +338,7 @@ describe("buildInfo", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
+      defaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -337,8 +347,8 @@ describe("buildInfo", () => {
     });
 
     it("send usage report if validateBstackJson fails", () => {
-      const info = proxyquire("../../../../bin/commands/info", {
-        "../helpers/utils": {
+      const info = proxyquire('../../../../bin/commands/info', {
+        '../helpers/utils': {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
@@ -346,7 +356,8 @@ describe("buildInfo", () => {
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
           setCypressConfigFilename: setCypressConfigFilenameStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
       });
 

--- a/test/unit/bin/commands/info.js
+++ b/test/unit/bin/commands/info.js
@@ -27,6 +27,7 @@ describe("buildInfo", () => {
       validateBstackJsonStub = sandbox.stub();
       getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
+      setCypressConfigFilenameStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -54,6 +55,7 @@ describe("buildInfo", () => {
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub
         },
@@ -90,6 +92,7 @@ describe("buildInfo", () => {
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub
         },
@@ -119,6 +122,7 @@ describe("buildInfo", () => {
       validateBstackJsonStub = sandbox.stub();
       getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
+      setCypressConfigFilenameStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -148,6 +152,7 @@ describe("buildInfo", () => {
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub
         },
@@ -182,18 +187,19 @@ describe("buildInfo", () => {
         .stub(request, "get")
         .yields(null, { statusCode: 401 }, JSON.stringify(body_with_message));
 
-      const info = proxyquire("../../../../bin/commands/info", {
-        "../helpers/utils": {
+      const info = proxyquire('../../../../bin/commands/info', {
+        '../helpers/utils': {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
         },
-        request: { get: requestStub },
+        request: {get: requestStub},
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -219,18 +225,19 @@ describe("buildInfo", () => {
         .stub(request, "get")
         .yields(null, { statusCode: 402 }, JSON.stringify(body));
 
-      const info = proxyquire("../../../../bin/commands/info", {
-        "../helpers/utils": {
+      const info = proxyquire('../../../../bin/commands/info', {
+        '../helpers/utils': {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
         },
-        request: { get: requestStub },
+        request: {get: requestStub},
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -258,6 +265,7 @@ describe("buildInfo", () => {
       validateBstackJsonStub = sandbox.stub();
       getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
+      setCypressConfigFilenameStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -277,18 +285,19 @@ describe("buildInfo", () => {
 
       let requestStub = sandbox.stub(request, "get").yields(null, { statusCode: 200 }, JSON.stringify(body));
 
-      const info = proxyquire("../../../../bin/commands/info", {
-        "../helpers/utils": {
+      const info = proxyquire('../../../../bin/commands/info', {
+        '../helpers/utils': {
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
         },
-        request: { get: requestStub },
+        request: {get: requestStub},
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -315,6 +324,7 @@ describe("buildInfo", () => {
       getConfigPathStub = sandbox.stub();
       validateBstackJsonStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
+      setCypressConfigFilenameStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
       });
@@ -335,6 +345,7 @@ describe("buildInfo", () => {
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getConfigPath: getConfigPathStub
         },
       });

--- a/test/unit/bin/commands/info.js
+++ b/test/unit/bin/commands/info.js
@@ -33,7 +33,7 @@ describe("buildInfo", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -59,7 +59,7 @@ describe("buildInfo", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         request: {get: requestStub},
       });
@@ -97,7 +97,7 @@ describe("buildInfo", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         request: {get: requestStub},
       });
@@ -131,7 +131,7 @@ describe("buildInfo", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -159,7 +159,7 @@ describe("buildInfo", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         request: {get: requestStub},
       });
@@ -203,7 +203,7 @@ describe("buildInfo", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         request: {get: requestStub},
       });
@@ -242,7 +242,7 @@ describe("buildInfo", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         request: {get: requestStub},
       });
@@ -278,7 +278,7 @@ describe("buildInfo", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -304,7 +304,7 @@ describe("buildInfo", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         request: {get: requestStub},
       });
@@ -338,7 +338,7 @@ describe("buildInfo", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -357,7 +357,7 @@ describe("buildInfo", () => {
           setUsageReportingFlag: setUsageReportingFlagStub,
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
       });
 

--- a/test/unit/bin/commands/init.js
+++ b/test/unit/bin/commands/init.js
@@ -78,10 +78,12 @@ describe("init", () => {
       };
 
       loggerStub = sandbox.stub(logger, 'error');
+      cypressConfigFileStub = sandbox.stub(utils, 'setCypressConfigFilename');
       usageStub = sandbox.stub(utils, 'sendUsageReport');
 
       expect(get_path(args)).to.be.undefined;
       sinon.assert.calledOnce(loggerStub);
+      sinon.assert.calledOnce(cypressConfigFileStub);
       sinon.assert.calledOnce(usageStub);
     });
 

--- a/test/unit/bin/commands/runs.js
+++ b/test/unit/bin/commands/runs.js
@@ -40,8 +40,8 @@ describe("runs", () => {
       let messageType = Constants.messageTypes.ERROR;
       let errorCode = "random-error-code";
 
-      const runs = proxyquire("../../../../bin/commands/runs", {
-        "../helpers/utils": {
+      const runs = proxyquire('../../../../bin/commands/runs', {
+        '../helpers/utils': {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
@@ -98,6 +98,7 @@ describe("runs", () => {
       setLocalStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
+      defaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -110,8 +111,8 @@ describe("runs", () => {
       let messageType = Constants.messageTypes.ERROR;
       let errorCode = "random-error-code";
 
-      const runs = proxyquire("../../../../bin/commands/runs", {
-        "../helpers/utils": {
+      const runs = proxyquire('../../../../bin/commands/runs', {
+        '../helpers/utils': {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromMsg: getErrorCodeFromMsgStub,
           sendUsageReport: sendUsageReportStub,
@@ -125,9 +126,10 @@ describe("runs", () => {
           getConfigPath: getConfigPathStub,
           setLocal: setLocalStub,
           setLocalIdentifier: setLocalIdentifierStub,
-          deleteResults: deleteResultsStub
+          deleteResults: deleteResultsStub,
+          defaultAuthHash: defaultAuthHashStub
         },
-        "../helpers/capabilityHelper": {
+        '../helpers/capabilityHelper': {
           validate: capabilityValidatorStub,
         },
       });
@@ -149,6 +151,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(setLocalStub);
           sinon.assert.calledOnce(setLocalIdentifierStub);
           sinon.assert.calledOnce(deleteResultsStub);
+          sinon.assert.calledOnce(defaultAuthHashStub);
           sinon.assert.calledOnceWithExactly(
             sendUsageReportStub,
             bsConfig,
@@ -185,6 +188,7 @@ describe("runs", () => {
       setLocalStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
+      defaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -197,8 +201,8 @@ describe("runs", () => {
       let messageType = Constants.messageTypes.ERROR;
       let errorCode = "zip_creation_failed";
 
-      const runs = proxyquire("../../../../bin/commands/runs", {
-        "../helpers/utils": {
+      const runs = proxyquire('../../../../bin/commands/runs', {
+        '../helpers/utils': {
           validateBstackJson: validateBstackJsonStub,
           sendUsageReport: sendUsageReportStub,
           setParallels: setParallelsStub,
@@ -212,17 +216,18 @@ describe("runs", () => {
           getConfigPath: getConfigPathStub,
           setLocal: setLocalStub,
           setLocalIdentifier: setLocalIdentifierStub,
-          deleteResults: deleteResultsStub
+          deleteResults: deleteResultsStub,
+          defaultAuthHash: defaultAuthHashStub
         },
-        "../helpers/capabilityHelper": {
+        '../helpers/capabilityHelper': {
           validate: capabilityValidatorStub,
         },
-        "../helpers/archiver": {
+        '../helpers/archiver': {
           archive: archiverStub,
         },
-        "../helpers/fileHelpers": {
-          deleteZip: deleteZipStub
-        }
+        '../helpers/fileHelpers': {
+          deleteZip: deleteZipStub,
+        },
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -245,6 +250,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(setUsageReportingFlagStub);
           sinon.assert.calledOnce(deleteZipStub);
           sinon.assert.calledOnce(deleteResultsStub);
+          sinon.assert.calledOnce(defaultAuthHashStub);
           sinon.assert.calledOnceWithExactly(
             sendUsageReportStub,
             bsConfig,
@@ -282,6 +288,7 @@ describe("runs", () => {
       setLocalStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
+      defaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -294,8 +301,8 @@ describe("runs", () => {
       let messageType = Constants.messageTypes.ERROR;
       let errorCode = "zip_upload_failed";
 
-      const runs = proxyquire("../../../../bin/commands/runs", {
-        "../helpers/utils": {
+      const runs = proxyquire('../../../../bin/commands/runs', {
+        '../helpers/utils': {
           validateBstackJson: validateBstackJsonStub,
           sendUsageReport: sendUsageReportStub,
           setParallels: setParallelsStub,
@@ -309,18 +316,19 @@ describe("runs", () => {
           getConfigPath: getConfigPathStub,
           setLocal: setLocalStub,
           setLocalIdentifier: setLocalIdentifierStub,
-          deleteResults: deleteResultsStub
+          deleteResults: deleteResultsStub,
+          defaultAuthHash: defaultAuthHashStub
         },
-        "../helpers/capabilityHelper": {
+        '../helpers/capabilityHelper': {
           validate: capabilityValidatorStub,
         },
-        "../helpers/archiver": {
+        '../helpers/archiver': {
           archive: archiverStub,
         },
-        "../helpers/fileHelpers": {
+        '../helpers/fileHelpers': {
           deleteZip: deleteZipStub,
         },
-        "../helpers/zipUpload": {
+        '../helpers/zipUpload': {
           zipUpload: zipUploadStub,
         },
       });
@@ -346,6 +354,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(setUsageReportingFlagStub);
           sinon.assert.calledOnce(zipUploadStub);
           sinon.assert.calledOnce(deleteResultsStub);
+          sinon.assert.calledOnce(defaultAuthHashStub);
           sinon.assert.calledOnceWithExactly(
             sendUsageReportStub,
             bsConfig,
@@ -387,6 +396,7 @@ describe("runs", () => {
       setLocalStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
+      defaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -399,8 +409,8 @@ describe("runs", () => {
       let messageType = Constants.messageTypes.ERROR;
       let errorCode = "build_failed";
 
-      const runs = proxyquire("../../../../bin/commands/runs", {
-        "../helpers/utils": {
+      const runs = proxyquire('../../../../bin/commands/runs', {
+        '../helpers/utils': {
           validateBstackJson: validateBstackJsonStub,
           sendUsageReport: sendUsageReportStub,
           setParallels: setParallelsStub,
@@ -414,21 +424,22 @@ describe("runs", () => {
           getConfigPath: getConfigPathStub,
           setLocal: setLocalStub,
           setLocalIdentifier: setLocalIdentifierStub,
-          deleteResults: deleteResultsStub
+          deleteResults: deleteResultsStub,
+          defaultAuthHash: defaultAuthHashStub
         },
-        "../helpers/capabilityHelper": {
+        '../helpers/capabilityHelper': {
           validate: capabilityValidatorStub,
         },
-        "../helpers/archiver": {
+        '../helpers/archiver': {
           archive: archiverStub,
         },
-        "../helpers/fileHelpers": {
+        '../helpers/fileHelpers': {
           deleteZip: deleteZipStub,
         },
-        "../helpers/zipUpload": {
+        '../helpers/zipUpload': {
           zipUpload: zipUploadStub,
         },
-        "../helpers/build": {
+        '../helpers/build': {
           createBuild: createBuildStub,
         },
       });
@@ -460,6 +471,7 @@ describe("runs", () => {
 
           sinon.assert.calledOnce(sendUsageReportStub);
           sinon.assert.calledOnce(deleteResultsStub);
+          sinon.assert.calledOnce(defaultAuthHashStub);
 
           sinon.assert.calledOnceWithExactly(
             sendUsageReportStub,
@@ -503,6 +515,7 @@ describe("runs", () => {
       deleteZipStub = sandbox.stub();
       exportResultsStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
+      defaultAuthHashStub = sandbox.stub();
       isUndefinedStub = sandbox.stub();
       setLocalStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
@@ -536,6 +549,7 @@ describe("runs", () => {
           setLocalIdentifier: setLocalIdentifierStub,
           exportResults: exportResultsStub,
           deleteResults: deleteResultsStub,
+          defaultAuthHash: defaultAuthHashStub,
           isUndefined: isUndefinedStub
         },
         "../helpers/capabilityHelper": {
@@ -584,6 +598,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(createBuildStub);
           sinon.assert.calledOnce(exportResultsStub);
           sinon.assert.calledOnce(deleteResultsStub);
+          sinon.assert.calledOnce(defaultAuthHashStub);
           sinon.assert.calledOnceWithExactly(
             sendUsageReportStub,
             bsConfig,

--- a/test/unit/bin/commands/runs.js
+++ b/test/unit/bin/commands/runs.js
@@ -98,7 +98,7 @@ describe("runs", () => {
       setLocalStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -127,7 +127,7 @@ describe("runs", () => {
           setLocal: setLocalStub,
           setLocalIdentifier: setLocalIdentifierStub,
           deleteResults: deleteResultsStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         '../helpers/capabilityHelper': {
           validate: capabilityValidatorStub,
@@ -151,7 +151,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(setLocalStub);
           sinon.assert.calledOnce(setLocalIdentifierStub);
           sinon.assert.calledOnce(deleteResultsStub);
-          sinon.assert.calledOnce(defaultAuthHashStub);
+          sinon.assert.calledOnce(setDefaultAuthHashStub);
           sinon.assert.calledOnceWithExactly(
             sendUsageReportStub,
             bsConfig,
@@ -188,7 +188,7 @@ describe("runs", () => {
       setLocalStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -217,7 +217,7 @@ describe("runs", () => {
           setLocal: setLocalStub,
           setLocalIdentifier: setLocalIdentifierStub,
           deleteResults: deleteResultsStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         '../helpers/capabilityHelper': {
           validate: capabilityValidatorStub,
@@ -250,7 +250,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(setUsageReportingFlagStub);
           sinon.assert.calledOnce(deleteZipStub);
           sinon.assert.calledOnce(deleteResultsStub);
-          sinon.assert.calledOnce(defaultAuthHashStub);
+          sinon.assert.calledOnce(setDefaultAuthHashStub);
           sinon.assert.calledOnceWithExactly(
             sendUsageReportStub,
             bsConfig,
@@ -288,7 +288,7 @@ describe("runs", () => {
       setLocalStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -317,7 +317,7 @@ describe("runs", () => {
           setLocal: setLocalStub,
           setLocalIdentifier: setLocalIdentifierStub,
           deleteResults: deleteResultsStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         '../helpers/capabilityHelper': {
           validate: capabilityValidatorStub,
@@ -354,7 +354,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(setUsageReportingFlagStub);
           sinon.assert.calledOnce(zipUploadStub);
           sinon.assert.calledOnce(deleteResultsStub);
-          sinon.assert.calledOnce(defaultAuthHashStub);
+          sinon.assert.calledOnce(setDefaultAuthHashStub);
           sinon.assert.calledOnceWithExactly(
             sendUsageReportStub,
             bsConfig,
@@ -396,7 +396,7 @@ describe("runs", () => {
       setLocalStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -425,7 +425,7 @@ describe("runs", () => {
           setLocal: setLocalStub,
           setLocalIdentifier: setLocalIdentifierStub,
           deleteResults: deleteResultsStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         '../helpers/capabilityHelper': {
           validate: capabilityValidatorStub,
@@ -471,7 +471,7 @@ describe("runs", () => {
 
           sinon.assert.calledOnce(sendUsageReportStub);
           sinon.assert.calledOnce(deleteResultsStub);
-          sinon.assert.calledOnce(defaultAuthHashStub);
+          sinon.assert.calledOnce(setDefaultAuthHashStub);
 
           sinon.assert.calledOnceWithExactly(
             sendUsageReportStub,
@@ -515,7 +515,7 @@ describe("runs", () => {
       deleteZipStub = sandbox.stub();
       exportResultsStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
       isUndefinedStub = sandbox.stub();
       setLocalStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
@@ -549,7 +549,7 @@ describe("runs", () => {
           setLocalIdentifier: setLocalIdentifierStub,
           exportResults: exportResultsStub,
           deleteResults: deleteResultsStub,
-          defaultAuthHash: defaultAuthHashStub,
+          setDefaultAuthHash: setDefaultAuthHashStub,
           isUndefined: isUndefinedStub
         },
         "../helpers/capabilityHelper": {
@@ -598,7 +598,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(createBuildStub);
           sinon.assert.calledOnce(exportResultsStub);
           sinon.assert.calledOnce(deleteResultsStub);
-          sinon.assert.calledOnce(defaultAuthHashStub);
+          sinon.assert.calledOnce(setDefaultAuthHashStub);
           sinon.assert.calledOnceWithExactly(
             sendUsageReportStub,
             bsConfig,

--- a/test/unit/bin/commands/stop.js
+++ b/test/unit/bin/commands/stop.js
@@ -33,7 +33,7 @@ describe("buildStop", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -61,7 +61,7 @@ describe("buildStop", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         request: {post: requestStub},
       });
@@ -99,7 +99,7 @@ describe("buildStop", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         request: {post: requestStub},
       });
@@ -132,7 +132,7 @@ describe("buildStop", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -160,7 +160,7 @@ describe("buildStop", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         request: {post: requestStub},
       });
@@ -205,7 +205,7 @@ describe("buildStop", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         request: {post: requestStub},
       });
@@ -245,7 +245,7 @@ describe("buildStop", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         request: {post: requestStub},
       });
@@ -280,7 +280,7 @@ describe("buildStop", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -308,7 +308,7 @@ describe("buildStop", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
         request: {post: requestStub},
       });
@@ -342,7 +342,7 @@ describe("buildStop", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
-      defaultAuthHashStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -361,7 +361,7 @@ describe("buildStop", () => {
           setUsageReportingFlag: setUsageReportingFlagStub,
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getConfigPath: getConfigPathStub,
-          defaultAuthHash: defaultAuthHashStub
+          setDefaultAuthHash: setDefaultAuthHashStub
         },
       });
 

--- a/test/unit/bin/commands/stop.js
+++ b/test/unit/bin/commands/stop.js
@@ -27,6 +27,7 @@ describe("buildStop", () => {
       setAccessKeyStub = sandbox.stub();
       getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
+      setCypressConfigFilenameStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -48,18 +49,19 @@ describe("buildStop", () => {
         .stub(request, "post")
         .yields(null, { statusCode: 299 }, null);
 
-      const stop = proxyquire("../../../../bin/commands/stop", {
-        "../helpers/utils": {
+      const stop = proxyquire('../../../../bin/commands/stop', {
+        '../helpers/utils': {
           validateBstackJson: validateBstackJsonStub,
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
         },
-        request: { post: requestStub },
+        request: {post: requestStub},
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -84,18 +86,19 @@ describe("buildStop", () => {
         .stub(request, "post")
         .yields(null, { statusCode: 299 }, JSON.stringify(body));
 
-      const stop = proxyquire("../../../../bin/commands/stop", {
-        "../helpers/utils": {
+      const stop = proxyquire('../../../../bin/commands/stop', {
+        '../helpers/utils': {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           sendUsageReport: sendUsageReportStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
         },
-        request: { post: requestStub },
+        request: {post: requestStub},
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -120,6 +123,7 @@ describe("buildStop", () => {
       validateBstackJsonStub = sandbox.stub();
       getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
+      setCypressConfigFilenameStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -141,18 +145,19 @@ describe("buildStop", () => {
         .stub(request, "post")
         .yields(null, { statusCode: 400 }, null);
 
-      const stop = proxyquire("../../../../bin/commands/stop", {
-        "../helpers/utils": {
+      const stop = proxyquire('../../../../bin/commands/stop', {
+        '../helpers/utils': {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
         },
-        request: { post: requestStub },
+        request: {post: requestStub},
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -184,18 +189,19 @@ describe("buildStop", () => {
         .stub(request, "post")
         .yields(null, { statusCode: 401 }, JSON.stringify(body_with_message));
 
-      const stop = proxyquire("../../../../bin/commands/stop", {
-        "../helpers/utils": {
+      const stop = proxyquire('../../../../bin/commands/stop', {
+        '../helpers/utils': {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
         },
-        request: { post: requestStub },
+        request: {post: requestStub},
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -222,18 +228,19 @@ describe("buildStop", () => {
         .stub(request, "post")
         .yields(null, { statusCode: 402 }, JSON.stringify(body));
 
-      const stop = proxyquire("../../../../bin/commands/stop", {
-        "../helpers/utils": {
+      const stop = proxyquire('../../../../bin/commands/stop', {
+        '../helpers/utils': {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
         },
-        request: { post: requestStub },
+        request: {post: requestStub},
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -260,6 +267,7 @@ describe("buildStop", () => {
       validateBstackJsonStub = sandbox.stub();
       getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
+      setCypressConfigFilenameStub = sandbox.stub().returns(undefined);
       getUserAgentStub = sandbox.stub().returns("random user-agent");
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
@@ -281,18 +289,19 @@ describe("buildStop", () => {
         .stub(request, "post")
         .yields(null, { statusCode: 200 }, JSON.stringify(body));
 
-      const stop = proxyquire("../../../../bin/commands/stop", {
-        "../helpers/utils": {
+      const stop = proxyquire('../../../../bin/commands/stop', {
+        '../helpers/utils': {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
-          getConfigPath: getConfigPathStub
+          getConfigPath: getConfigPathStub,
         },
-        request: { post: requestStub },
+        request: {post: requestStub},
       });
 
       validateBstackJsonStub.returns(Promise.resolve(bsConfig));
@@ -319,6 +328,7 @@ describe("buildStop", () => {
       validateBstackJsonStub = sandbox.stub();
       getConfigPathStub = sandbox.stub();
       setUsageReportingFlagStub = sandbox.stub().returns(undefined);
+      setCypressConfigFilenameStub = sandbox.stub().returns(undefined);
       sendUsageReportStub = sandbox.stub().callsFake(function () {
         return "end";
       });
@@ -331,15 +341,16 @@ describe("buildStop", () => {
     });
 
     it("send usage report if validateBstackJson fails", () => {
-      const stop = proxyquire("../../../../bin/commands/stop", {
-        "../helpers/utils": {
+      const stop = proxyquire('../../../../bin/commands/stop', {
+        '../helpers/utils': {
           validateBstackJson: validateBstackJsonStub,
           getErrorCodeFromErr: getErrorCodeFromErrStub,
           sendUsageReport: sendUsageReportStub,
           setUsername: setUsernameStub,
           setAccessKey: setAccessKeyStub,
           setUsageReportingFlag: setUsageReportingFlagStub,
-          getConfigPath: getConfigPathStub
+          setCypressConfigFilename: setCypressConfigFilenameStub,
+          getConfigPath: getConfigPathStub,
         },
       });
 

--- a/test/unit/bin/commands/stop.js
+++ b/test/unit/bin/commands/stop.js
@@ -33,6 +33,7 @@ describe("buildStop", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
+      defaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -60,6 +61,7 @@ describe("buildStop", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
         request: {post: requestStub},
       });
@@ -97,6 +99,7 @@ describe("buildStop", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
         request: {post: requestStub},
       });
@@ -129,6 +132,7 @@ describe("buildStop", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
+      defaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -156,6 +160,7 @@ describe("buildStop", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
         request: {post: requestStub},
       });
@@ -200,6 +205,7 @@ describe("buildStop", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
         request: {post: requestStub},
       });
@@ -239,6 +245,7 @@ describe("buildStop", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
         request: {post: requestStub},
       });
@@ -273,6 +280,7 @@ describe("buildStop", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
+      defaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -300,6 +308,7 @@ describe("buildStop", () => {
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getUserAgent: getUserAgentStub,
           getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
         request: {post: requestStub},
       });
@@ -333,6 +342,7 @@ describe("buildStop", () => {
         return "end";
       });
       getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
+      defaultAuthHashStub = sandbox.stub();
     });
 
     afterEach(() => {
@@ -351,6 +361,7 @@ describe("buildStop", () => {
           setUsageReportingFlag: setUsageReportingFlagStub,
           setCypressConfigFilename: setCypressConfigFilenameStub,
           getConfigPath: getConfigPathStub,
+          defaultAuthHash: defaultAuthHashStub
         },
       });
 

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -1,158 +1,221 @@
 'use strict';
 const path = require('path');
 
-const chai = require("chai"),
+const chai = require('chai'),
   expect = chai.expect,
   sinon = require('sinon'),
-  chaiAsPromised = require("chai-as-promised"),
+  chaiAsPromised = require('chai-as-promised'),
   fs = require('fs');
 
 const utils = require('../../../../bin/helpers/utils'),
   constant = require('../../../../bin/helpers/constants'),
   logger = require('../../../../bin/helpers/logger').winstonLogger,
-  testObjects = require("../../support/fixtures/testObjects");
+  testObjects = require('../../support/fixtures/testObjects');
 
 chai.use(chaiAsPromised);
-logger.transports["console.info"].silent = true;
+logger.transports['console.info'].silent = true;
 
-describe("utils", () => {
-  describe("getErrorCodeFromMsg", () => {
+describe('utils', () => {
+  describe('getErrorCodeFromMsg', () => {
     it("should return null for errMsg which isn't present in the list", () => {
-      expect(utils.getErrorCodeFromMsg("random_value")).to.be.null;
+      expect(utils.getErrorCodeFromMsg('random_value')).to.be.null;
     });
 
     it(`should return value depending on validation messages`, () => {
-      expect(utils.getErrorCodeFromMsg(constant.validationMessages.EMPTY_BROWSERSTACK_JSON)).to.eq("bstack_json_invalid_empty");
-      expect(utils.getErrorCodeFromMsg(constant.validationMessages.INCORRECT_AUTH_PARAMS)).to.eq("bstack_json_invalid_missing_keys");
-      expect(utils.getErrorCodeFromMsg(constant.validationMessages.EMPTY_BROWSER_LIST)).to.eq("bstack_json_invalid_no_browsers");
-      expect(utils.getErrorCodeFromMsg(constant.validationMessages.EMPTY_RUN_SETTINGS)).to.eq("bstack_json_invalid_no_run_settings");
-      expect(utils.getErrorCodeFromMsg(constant.validationMessages.EMPTY_CYPRESS_PROJ_DIR)).to.eq("bstack_json_invalid_no_cypress_proj_dir");
-      expect(utils.getErrorCodeFromMsg(constant.validationMessages.INVALID_DEFAULT_AUTH_PARAMS)).to.eq("bstack_json_default_auth_keys");
-      expect(utils.getErrorCodeFromMsg(constant.validationMessages.INVALID_PARALLELS_CONFIGURATION)).to.eq("invalid_parallels_specified");
-      expect(utils.getErrorCodeFromMsg(constant.validationMessages.LOCAL_NOT_SET)).to.eq("cypress_json_base_url_no_local");
-      expect(utils.getErrorCodeFromMsg(constant.validationMessages.INCORRECT_DIRECTORY_STRUCTURE)).to.eq("invalid_directory_structure");
-      expect(utils.getErrorCodeFromMsg("Please use --config-file <path to browserstack.json>.")).to.eq("bstack_json_path_invalid");
+      expect(
+        utils.getErrorCodeFromMsg(
+          constant.validationMessages.EMPTY_BROWSERSTACK_JSON
+        )
+      ).to.eq('bstack_json_invalid_empty');
+      expect(
+        utils.getErrorCodeFromMsg(
+          constant.validationMessages.INCORRECT_AUTH_PARAMS
+        )
+      ).to.eq('bstack_json_invalid_missing_keys');
+      expect(
+        utils.getErrorCodeFromMsg(
+          constant.validationMessages.EMPTY_BROWSER_LIST
+        )
+      ).to.eq('bstack_json_invalid_no_browsers');
+      expect(
+        utils.getErrorCodeFromMsg(
+          constant.validationMessages.EMPTY_RUN_SETTINGS
+        )
+      ).to.eq('bstack_json_invalid_no_run_settings');
+      expect(
+        utils.getErrorCodeFromMsg(
+          constant.validationMessages.EMPTY_CYPRESS_PROJ_DIR
+        )
+      ).to.eq('bstack_json_invalid_no_cypress_proj_dir');
+      expect(
+        utils.getErrorCodeFromMsg(
+          constant.validationMessages.INVALID_DEFAULT_AUTH_PARAMS
+        )
+      ).to.eq('bstack_json_default_auth_keys');
+      expect(
+        utils.getErrorCodeFromMsg(
+          constant.validationMessages.INVALID_PARALLELS_CONFIGURATION
+        )
+      ).to.eq('invalid_parallels_specified');
+      expect(
+        utils.getErrorCodeFromMsg(constant.validationMessages.LOCAL_NOT_SET)
+      ).to.eq('cypress_json_base_url_no_local');
+      expect(
+        utils.getErrorCodeFromMsg(
+          constant.validationMessages.INCORRECT_DIRECTORY_STRUCTURE
+        )
+      ).to.eq('invalid_directory_structure');
+      expect(
+        utils.getErrorCodeFromMsg(
+          'Please use --config-file <path to browserstack.json>.'
+        )
+      ).to.eq('bstack_json_path_invalid');
     });
   });
 
-  describe("isParallelValid", () => {
-    it("should return false for a float value", () => {
+  describe('isParallelValid', () => {
+    it('should return false for a float value', () => {
       expect(utils.isParallelValid(1.2)).to.be.equal(false);
-      expect(utils.isParallelValid("7.3")).to.be.equal(false);
+      expect(utils.isParallelValid('7.3')).to.be.equal(false);
       expect(utils.isParallelValid(7.33333)).to.be.equal(false);
-      expect(utils.isParallelValid("1.2.2.2")).to.be.equal(false);
-      expect(utils.isParallelValid("1.456789")).to.be.equal(false);
+      expect(utils.isParallelValid('1.2.2.2')).to.be.equal(false);
+      expect(utils.isParallelValid('1.456789')).to.be.equal(false);
     });
 
-    it("should return false for a string which is not a number", () => {
-      expect(utils.isParallelValid("cypress")).to.be.equal(false);
-      expect(utils.isParallelValid("browserstack")).to.be.equal(false);
+    it('should return false for a string which is not a number', () => {
+      expect(utils.isParallelValid('cypress')).to.be.equal(false);
+      expect(utils.isParallelValid('browserstack')).to.be.equal(false);
     });
 
-    it("should return false for any negative value less than -1 or zero", () => {
+    it('should return false for any negative value less than -1 or zero', () => {
       expect(utils.isParallelValid(-200)).to.be.equal(false);
-      expect(utils.isParallelValid("-200")).to.be.equal(false);
+      expect(utils.isParallelValid('-200')).to.be.equal(false);
       expect(utils.isParallelValid(-1000)).to.be.equal(false);
-      expect(utils.isParallelValid("0")).to.be.equal(false);
+      expect(utils.isParallelValid('0')).to.be.equal(false);
       expect(utils.isParallelValid(0)).to.be.equal(false);
     });
 
-    it("should return true for any positive value or -1", () => {
+    it('should return true for any positive value or -1', () => {
       expect(utils.isParallelValid(5)).to.be.equal(true);
-      expect(utils.isParallelValid("5")).to.be.equal(true);
+      expect(utils.isParallelValid('5')).to.be.equal(true);
       expect(utils.isParallelValid(10)).to.be.equal(true);
-      expect(utils.isParallelValid("-1")).to.be.equal(true);
+      expect(utils.isParallelValid('-1')).to.be.equal(true);
       expect(utils.isParallelValid(-1)).to.be.equal(true);
     });
 
-    it("should return true for undefined", () => {
+    it('should return true for undefined', () => {
       expect(utils.isParallelValid(undefined)).to.be.equal(true);
     });
   });
 
-  describe("isFloat", () => {
-    it("should return true for a float value", () => {
+  describe('isFloat', () => {
+    it('should return true for a float value', () => {
       expect(utils.isFloat(1.2333)).to.be.equal(true);
       expect(utils.isFloat(-1.2333567)).to.be.equal(true);
       expect(utils.isFloat(0.123456)).to.be.equal(true);
     });
 
-    it("should return false for a non float value", () => {
+    it('should return false for a non float value', () => {
       expect(utils.isFloat(100)).to.be.equal(false);
       expect(utils.isFloat(-1000)).to.be.equal(false);
       expect(utils.isFloat(333)).to.be.equal(false);
     });
   });
 
-  describe("isUndefined", () => {
-    it("should return true for a undefined value", () => {
+  describe('isUndefined', () => {
+    it('should return true for a undefined value', () => {
       expect(utils.isUndefined(undefined)).to.be.equal(true);
       expect(utils.isUndefined(null)).to.be.equal(true);
     });
 
-    it("should return false for a defined value", () => {
+    it('should return false for a defined value', () => {
       expect(utils.isUndefined(1.234)).to.be.equal(false);
-      expect(utils.isUndefined("1.234")).to.be.equal(false);
+      expect(utils.isUndefined('1.234')).to.be.equal(false);
       expect(utils.isUndefined(100)).to.be.equal(false);
       expect(utils.isUndefined(-1)).to.be.equal(false);
     });
   });
 
-  describe("setParallels", () => {
-    it("should set bsconfig parallels equal to value provided in args", () => {
+  describe('setParallels', () => {
+    it('should set bsconfig parallels equal to value provided in args', () => {
       let bsConfig = {
-        "run_settings": {
-          "parallels": 10,
-        }
+        run_settings: {
+          parallels: 10,
+        },
       };
-      utils.setParallels(bsConfig, { parallels: 100 });
+      utils.setParallels(bsConfig, {parallels: 100});
       expect(bsConfig['run_settings']['parallels']).to.be.eq(100);
     });
 
-    it("should retain bsconfig parallels if args is undefined", () => {
+    it('should retain bsconfig parallels if args is undefined', () => {
       let bsConfig = {
-        "run_settings": {
-          "parallels": 10,
-        }
+        run_settings: {
+          parallels: 10,
+        },
       };
-      utils.setParallels(bsConfig, { parallels: undefined });
+      utils.setParallels(bsConfig, {parallels: undefined});
       expect(bsConfig['run_settings']['parallels']).to.be.eq(10);
     });
   });
 
-  describe("getErrorCodeFromErr", () => {
-    it("should return bstack_json_invalid_unknown if err.Code is not present in the list", () => {
-      expect(utils.getErrorCodeFromErr("random_value")).to.be.eq("bstack_json_invalid_unknown");
+  describe('getErrorCodeFromErr', () => {
+    it('should return bstack_json_invalid_unknown if err.Code is not present in the list', () => {
+      expect(utils.getErrorCodeFromErr('random_value')).to.be.eq(
+        'bstack_json_invalid_unknown'
+      );
     });
 
     it(`should return value depending on validation messages`, () => {
-      expect(utils.getErrorCodeFromErr({ "code": "SyntaxError" })).to.eq("bstack_json_parse_error");
-      expect(utils.getErrorCodeFromErr({ "code": "EACCES" })).to.eq("bstack_json_no_permission");
+      expect(utils.getErrorCodeFromErr({code: 'SyntaxError'})).to.eq(
+        'bstack_json_parse_error'
+      );
+      expect(utils.getErrorCodeFromErr({code: 'EACCES'})).to.eq(
+        'bstack_json_no_permission'
+      );
     });
   });
 
-  describe("getUserAgent", () => {
-    it("should return string", () => {
+  describe('getUserAgent', () => {
+    it('should return string', () => {
       expect(utils.getUserAgent()).to.be.string;
     });
   });
 
-  describe("validateBstackJson", () => {
-    it("should reject with SyntaxError for empty file", () => {
-      let bsConfigPath = path.join(process.cwd(), 'test', 'test_files', 'dummy_bstack.json');
-      expect(utils.validateBstackJson(bsConfigPath)).to.be.rejectedWith(SyntaxError);
+  describe('validateBstackJson', () => {
+    it('should reject with SyntaxError for empty file', () => {
+      let bsConfigPath = path.join(
+        process.cwd(),
+        'test',
+        'test_files',
+        'dummy_bstack.json'
+      );
+      expect(utils.validateBstackJson(bsConfigPath)).to.be.rejectedWith(
+        SyntaxError
+      );
     });
-    it("should resolve with data for valid json", () => {
-      let bsConfigPath = path.join(process.cwd(), 'test', 'test_files', 'dummy_bstack_2.json');
+    it('should resolve with data for valid json', () => {
+      let bsConfigPath = path.join(
+        process.cwd(),
+        'test',
+        'test_files',
+        'dummy_bstack_2.json'
+      );
       expect(utils.validateBstackJson(bsConfigPath)).to.be.eventually.eql({});
     });
-    it("should reject with SyntaxError for invalid json file", () => {
-      let bsConfigPath = path.join(process.cwd(), 'test', 'test_files', 'dummy_bstack_3.json');
-      expect(utils.validateBstackJson(bsConfigPath)).to.be.rejectedWith(SyntaxError);
+    it('should reject with SyntaxError for invalid json file', () => {
+      let bsConfigPath = path.join(
+        process.cwd(),
+        'test',
+        'test_files',
+        'dummy_bstack_3.json'
+      );
+      expect(utils.validateBstackJson(bsConfigPath)).to.be.rejectedWith(
+        SyntaxError
+      );
     });
   });
 
-  describe("setUsageReportingFlag", () => {
+  describe('setUsageReportingFlag', () => {
     beforeEach(function () {
       delete process.env.DISABLE_USAGE_REPORTING;
     });
@@ -161,98 +224,102 @@ describe("utils", () => {
       delete process.env.DISABLE_USAGE_REPORTING;
     });
 
-    it("should set env variable if no args are defined", () => {
+    it('should set env variable if no args are defined', () => {
       utils.setUsageReportingFlag(undefined, undefined);
-      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq("undefined");
+      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq('undefined');
     });
 
-    it("should set DISABLE_USAGE_REPORTING=true when disableUsageReporting=true", () => {
+    it('should set DISABLE_USAGE_REPORTING=true when disableUsageReporting=true', () => {
       utils.setUsageReportingFlag(undefined, true);
-      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq("true");
+      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq('true');
     });
 
-    it("should set DISABLE_USAGE_REPORTING=false when disableUsageReporting=false", () => {
+    it('should set DISABLE_USAGE_REPORTING=false when disableUsageReporting=false', () => {
       utils.setUsageReportingFlag(undefined, false);
-      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq("false");
+      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq('false');
     });
 
-    it("should set DISABLE_USAGE_REPORTING=true if defined in bsConfig", () => {
+    it('should set DISABLE_USAGE_REPORTING=true if defined in bsConfig', () => {
       let bsConfig = {
-        "disable_usage_reporting": true,
+        disable_usage_reporting: true,
       };
       utils.setUsageReportingFlag(bsConfig, undefined);
-      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq("true");
+      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq('true');
     });
 
-    it("should set DISABLE_USAGE_REPORTING=false if defined in bsConfig", () => {
+    it('should set DISABLE_USAGE_REPORTING=false if defined in bsConfig', () => {
       let bsConfig = {
-        "disable_usage_reporting": false,
+        disable_usage_reporting: false,
       };
       utils.setUsageReportingFlag(bsConfig, undefined);
-      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq("false");
+      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq('false');
     });
 
-    it("should give priority to disableUsageReporting arg", () => {
+    it('should give priority to disableUsageReporting arg', () => {
       let bsConfig = {
-        "disable_usage_reporting": true,
+        disable_usage_reporting: true,
       };
       utils.setUsageReportingFlag(bsConfig, false);
-      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq("false");
+      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq('false');
     });
 
-    it("should handle both bsConfig and disableUsageReporting arg", () => {
+    it('should handle both bsConfig and disableUsageReporting arg', () => {
       let bsConfig = {
-        "disable_usage_reporting": true,
+        disable_usage_reporting: true,
       };
       utils.setUsageReportingFlag(bsConfig, true);
-      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq("true");
+      expect(process.env.DISABLE_USAGE_REPORTING).to.be.eq('true');
     });
   });
 
-  describe("isAbsolute", () => {
-    it("should return true when path is absolute", () => {
-      expect(utils.isAbsolute("/Absolute/Path")).to.be.true;
+  describe('isAbsolute', () => {
+    it('should return true when path is absolute', () => {
+      expect(utils.isAbsolute('/Absolute/Path')).to.be.true;
     });
 
-    it("should return false when path is relative", () => {
-      expect(utils.isAbsolute("../Relative/Path")).to.be.false;
-    });
-  });
-
-  describe("getConfigPath", () => {
-    it("should return given path, when path is absolute", () => {
-      expect(utils.getConfigPath("/Absolute/Path")).to.be.eq("/Absolute/Path");
-    });
-
-    it("should return path joined with current dir path, when path is relative", () => {
-      let configPath = "../Relative/Path"
-      expect(utils.getConfigPath(configPath)).to.be.eq(path.join(process.cwd(), configPath));
+    it('should return false when path is relative', () => {
+      expect(utils.isAbsolute('../Relative/Path')).to.be.false;
     });
   });
 
-  describe("configCreated", () => {
+  describe('getConfigPath', () => {
+    it('should return given path, when path is absolute', () => {
+      expect(utils.getConfigPath('/Absolute/Path')).to.be.eq('/Absolute/Path');
+    });
+
+    it('should return path joined with current dir path, when path is relative', () => {
+      let configPath = '../Relative/Path';
+      expect(utils.getConfigPath(configPath)).to.be.eq(
+        path.join(process.cwd(), configPath)
+      );
+    });
+  });
+
+  describe('configCreated', () => {
     let args = testObjects.initSampleArgs;
 
-    it("should call sendUsageReport", () => {
+    it('should call sendUsageReport', () => {
       sandbox = sinon.createSandbox();
-      sendUsageReportStub = sandbox.stub(utils, "sendUsageReport").callsFake(function () {
-        return "end";
-      });
+      sendUsageReportStub = sandbox
+        .stub(utils, 'sendUsageReport')
+        .callsFake(function () {
+          return 'end';
+        });
       utils.configCreated(args);
       sinon.assert.calledOnce(sendUsageReportStub);
     });
   });
 
-  describe("setBuildName", () => {
-    it("sets the build name from args list", () => {
-      let argBuildName = "argBuildName";
+  describe('setBuildName', () => {
+    it('sets the build name from args list', () => {
+      let argBuildName = 'argBuildName';
       let bsConfig = {
         run_settings: {
-          build_name: "build_name"
-        }
+          build_name: 'build_name',
+        },
       };
       let args = {
-        'build-name': argBuildName
+        'build-name': argBuildName,
       };
 
       utils.setBuildName(bsConfig, args);
@@ -260,16 +327,16 @@ describe("utils", () => {
     });
   });
 
-  describe("setUsername", () => {
-    it("sets the username from args list", () => {
-      let argUserName = "argUserName";
+  describe('setUsername', () => {
+    it('sets the username from args list', () => {
+      let argUserName = 'argUserName';
       let bsConfig = {
         auth: {
-          username: "username"
-        }
+          username: 'username',
+        },
       };
       let args = {
-        username: argUserName
+        username: argUserName,
       };
 
       utils.setUsername(bsConfig, args);
@@ -277,16 +344,16 @@ describe("utils", () => {
     });
   });
 
-  describe("setAccessKey", () => {
-    it("sets the access key from args list", () => {
-      let argAccessKey = "argAccessKey";
+  describe('setAccessKey', () => {
+    it('sets the access key from args list', () => {
+      let argAccessKey = 'argAccessKey';
       let bsConfig = {
         auth: {
-          access_key: "access_key"
-        }
+          access_key: 'access_key',
+        },
       };
       let args = {
-        key: argAccessKey
+        key: argAccessKey,
       };
 
       utils.setAccessKey(bsConfig, args);
@@ -294,86 +361,85 @@ describe("utils", () => {
     });
   });
 
-  describe("setUserSpecs", () => {
-    it("sets the specs from args list without space after comma with single space in given list", () => {
-      let argsSpecs = "spec3, spec4";
+  describe('setUserSpecs', () => {
+    it('sets the specs from args list without space after comma with single space in given list', () => {
+      let argsSpecs = 'spec3, spec4';
       let bsConfig = {
         run_settings: {
-          specs: "spec1, spec2"
-        }
+          specs: 'spec1, spec2',
+        },
       };
       let args = {
-        specs: argsSpecs
+        specs: argsSpecs,
       };
 
       utils.setUserSpecs(bsConfig, args);
       expect(bsConfig.run_settings.specs).to.be.eq('spec3,spec4');
     });
 
-    it("sets the specs from args list without space after comma with spaces in given list", () => {
-      let argsSpecs = "spec3 , spec4";
+    it('sets the specs from args list without space after comma with spaces in given list', () => {
+      let argsSpecs = 'spec3 , spec4';
       let bsConfig = {
         run_settings: {
-          specs: "spec1, spec2"
-        }
+          specs: 'spec1, spec2',
+        },
       };
       let args = {
-        specs: argsSpecs
+        specs: argsSpecs,
       };
 
       utils.setUserSpecs(bsConfig, args);
       expect(bsConfig.run_settings.specs).to.be.eq('spec3,spec4');
     });
 
-    it("sets the specs list from specs key without space after comma with once space after comma in given list", () => {
+    it('sets the specs list from specs key without space after comma with once space after comma in given list', () => {
       let bsConfig = {
         run_settings: {
-          specs: "spec1, spec2"
-        }
+          specs: 'spec1, spec2',
+        },
       };
       let args = {
-        specs: null
+        specs: null,
       };
 
       utils.setUserSpecs(bsConfig, args);
       expect(bsConfig.run_settings.specs).to.be.eq('spec1,spec2');
     });
 
-    it("sets the specs list from specs key without space after comma with extra space in given list", () => {
+    it('sets the specs list from specs key without space after comma with extra space in given list', () => {
       let bsConfig = {
         run_settings: {
-          specs: "spec1 , spec2"
-        }
+          specs: 'spec1 , spec2',
+        },
       };
       let args = {
-        specs: null
+        specs: null,
       };
 
       utils.setUserSpecs(bsConfig, args);
       expect(bsConfig.run_settings.specs).to.be.eq('spec1,spec2');
     });
 
-    it("sets the specs list from specs key array without space with comma", () => {
+    it('sets the specs list from specs key array without space with comma', () => {
       let bsConfig = {
         run_settings: {
-          specs: ["spec1", "spec2"]
-        }
+          specs: ['spec1', 'spec2'],
+        },
       };
       let args = {
-        specs: null
+        specs: null,
       };
 
       utils.setUserSpecs(bsConfig, args);
       expect(bsConfig.run_settings.specs).to.be.eq('spec1,spec2');
     });
 
-    it("does not set the specs list if no specs key specified", () => {
+    it('does not set the specs list if no specs key specified', () => {
       let bsConfig = {
-        run_settings: {
-        }
+        run_settings: {},
       };
       let args = {
-        specs: null
+        specs: null,
       };
 
       utils.setUserSpecs(bsConfig, args);
@@ -381,46 +447,46 @@ describe("utils", () => {
     });
   });
 
-  describe("setTestEnvs", () => {
-    it("sets env only from args", () => {
-      let argsEnv = "env3=value3, env4=value4";
+  describe('setTestEnvs', () => {
+    it('sets env only from args', () => {
+      let argsEnv = 'env3=value3, env4=value4';
       let bsConfig = {
         run_settings: {
-          env: "env1=value1, env2=value2"
-        }
+          env: 'env1=value1, env2=value2',
+        },
       };
       let args = {
-        env: argsEnv
+        env: argsEnv,
       };
 
       utils.setTestEnvs(bsConfig, args);
       expect(bsConfig.run_settings.env).to.be.eq('env3=value3,env4=value4');
     });
 
-    it("sets env from args without spaces in it", () => {
-      let argsEnv = "env3=value3 , env4=value4";
+    it('sets env from args without spaces in it', () => {
+      let argsEnv = 'env3=value3 , env4=value4';
       let bsConfig = {
         run_settings: {
-          env: "env1=value1 , env2=value2"
-        }
+          env: 'env1=value1 , env2=value2',
+        },
       };
       let args = {
-        env: argsEnv
+        env: argsEnv,
       };
 
       utils.setTestEnvs(bsConfig, args);
       expect(bsConfig.run_settings.env).to.be.eq('env3=value3,env4=value4');
     });
 
-    it("does not set env if not specified in args", () => {
-      let argsEnv = "env3=value3 , env4=value4";
+    it('does not set env if not specified in args', () => {
+      let argsEnv = 'env3=value3 , env4=value4';
       let bsConfig = {
         run_settings: {
-          env: "env1=value1 , env2=value2"
-        }
+          env: 'env1=value1 , env2=value2',
+        },
       };
       let args = {
-        env: null
+        env: null,
       };
 
       utils.setTestEnvs(bsConfig, args);
@@ -428,88 +494,92 @@ describe("utils", () => {
     });
   });
 
-  describe("fixCommaSeparatedString", () => {
-    it("string with spaces after comma", () => {
-      let commaString = "string1, string2";
+  describe('fixCommaSeparatedString', () => {
+    it('string with spaces after comma', () => {
+      let commaString = 'string1, string2';
       let result = utils.fixCommaSeparatedString(commaString);
       expect(result).to.be.eq('string1,string2');
     });
 
-    it("string with spaces around comma", () => {
-      let commaString = "string1 , string2";
+    it('string with spaces around comma', () => {
+      let commaString = 'string1 , string2';
       let result = utils.fixCommaSeparatedString(commaString);
       expect(result).to.be.eq('string1,string2');
     });
 
-    it("string with 2 spaces around comma", () => {
-      let commaString = "string1  ,  string2";
+    it('string with 2 spaces around comma', () => {
+      let commaString = 'string1  ,  string2';
       let result = utils.fixCommaSeparatedString(commaString);
       expect(result).to.be.eq('string1,string2');
     });
   });
 
-  describe("exportResults", () => {
-
-    it("should export results to log/build_results.txt", () => {
+  describe('exportResults', () => {
+    it('should export results to log/build_results.txt', () => {
       sinon.stub(fs, 'writeFileSync').returns(true);
-      utils.exportResults("build_id", "build_url");
+      utils.exportResults('build_id', 'build_url');
       fs.writeFileSync.restore();
     });
 
-    it("should log warning if write to log/build_results.txt fails", () => {
+    it('should log warning if write to log/build_results.txt fails', () => {
       let writeFileSyncStub = sinon.stub(fs, 'writeFileSync');
-      let loggerWarnStub = sinon.stub(logger, "warn");
-      writeFileSyncStub.yields(new Error("Write Failed"));
-      utils.exportResults("build_id", "build_url");
+      let loggerWarnStub = sinon.stub(logger, 'warn');
+      writeFileSyncStub.yields(new Error('Write Failed'));
+      utils.exportResults('build_id', 'build_url');
       sinon.assert.calledOnce(writeFileSyncStub);
       sinon.assert.calledTwice(loggerWarnStub);
       fs.writeFileSync.restore();
     });
-
   });
 
-  describe("deleteResults", () => {
-
-    it("should delete log/build_results.txt", () => {
+  describe('deleteResults', () => {
+    it('should delete log/build_results.txt', () => {
       sinon.stub(fs, 'unlink').returns(true);
       utils.deleteResults();
       fs.unlink.restore();
     });
   });
 
-  describe("isCypressProjDirValid", () => {
-    it("should return true when cypressDir and cypressProjDir is same", () => {
-      expect(utils.isCypressProjDirValid("/absolute/path", "/absolute/path")).to.be.true;
+  describe('isCypressProjDirValid', () => {
+    it('should return true when cypressDir and cypressProjDir is same', () => {
+      expect(utils.isCypressProjDirValid('/absolute/path', '/absolute/path')).to
+        .be.true;
     });
 
-    it("should return true when cypressProjDir is child directory of cypressDir", () => {
-      expect(utils.isCypressProjDirValid("/absolute/path", "/absolute/path/childpath")).to.be.true;
+    it('should return true when cypressProjDir is child directory of cypressDir', () => {
+      expect(
+        utils.isCypressProjDirValid(
+          '/absolute/path',
+          '/absolute/path/childpath'
+        )
+      ).to.be.true;
     });
 
-    it("should return false when cypressProjDir is not child directory of cypressDir", () => {
-      expect(utils.isCypressProjDirValid("/absolute/path", "/absolute")).to.be.false;
+    it('should return false when cypressProjDir is not child directory of cypressDir', () => {
+      expect(utils.isCypressProjDirValid('/absolute/path', '/absolute')).to.be
+        .false;
     });
   });
 
-  describe("getLocalFlag", () => {
-    it("should return false if connectionSettings is undefined", () => {
+  describe('getLocalFlag', () => {
+    it('should return false if connectionSettings is undefined', () => {
       expect(utils.getLocalFlag(undefined)).to.be.false;
     });
 
-    it("should return false if connectionSettings.local is undefined", () => {
+    it('should return false if connectionSettings.local is undefined', () => {
       expect(utils.getLocalFlag({})).to.be.false;
     });
 
-    it("should return false if connectionSettings.local is false", () => {
-      expect(utils.getLocalFlag({ "local": false })).to.be.false;
+    it('should return false if connectionSettings.local is false', () => {
+      expect(utils.getLocalFlag({local: false})).to.be.false;
     });
 
-    it("should return true if connectionSettings.local is true", () => {
-      expect(utils.getLocalFlag({ "local": true })).to.be.true;
+    it('should return true if connectionSettings.local is true', () => {
+      expect(utils.getLocalFlag({local: true})).to.be.true;
     });
   });
 
-  describe("setLocal", () => {
+  describe('setLocal', () => {
     beforeEach(function () {
       delete process.env.BROWSERSTACK_LOCAL;
     });
@@ -518,51 +588,49 @@ describe("utils", () => {
       delete process.env.BROWSERSTACK_LOCAL;
     });
 
-    it("should not change local in bsConfig if process.env.BROWSERSTACK_LOCAL is undefined", () => {
+    it('should not change local in bsConfig if process.env.BROWSERSTACK_LOCAL is undefined', () => {
       let bsConfig = {
         connection_settings: {
-          local: true
-        }
-      }
+          local: true,
+        },
+      };
       utils.setLocal(bsConfig);
       expect(bsConfig.connection_settings.local).to.be.eq(true);
     });
 
-    it("should change local to false in bsConfig if process.env.BROWSERSTACK_LOCAL is set to false", () => {
+    it('should change local to false in bsConfig if process.env.BROWSERSTACK_LOCAL is set to false', () => {
       let bsConfig = {
         connection_settings: {
-          local: true
-        }
-      }
+          local: true,
+        },
+      };
       process.env.BROWSERSTACK_LOCAL = false;
       utils.setLocal(bsConfig);
       expect(bsConfig.connection_settings.local).to.be.eq(false);
     });
 
-    it("should change local to true in bsConfig if process.env.BROWSERSTACK_LOCAL is set to true", () => {
+    it('should change local to true in bsConfig if process.env.BROWSERSTACK_LOCAL is set to true', () => {
       let bsConfig = {
         connection_settings: {
-          local: false
-        }
-      }
+          local: false,
+        },
+      };
       process.env.BROWSERSTACK_LOCAL = true;
       utils.setLocal(bsConfig);
       expect(bsConfig.connection_settings.local).to.be.eq(true);
     });
 
-    it("should set local to true in bsConfig if process.env.BROWSERSTACK_LOCAL is set to true & local is not set in bsConfig", () => {
+    it('should set local to true in bsConfig if process.env.BROWSERSTACK_LOCAL is set to true & local is not set in bsConfig', () => {
       let bsConfig = {
-        connection_settings: {
-        }
-      }
+        connection_settings: {},
+      };
       process.env.BROWSERSTACK_LOCAL = true;
       utils.setLocal(bsConfig);
       expect(bsConfig.connection_settings.local).to.be.eq(true);
     });
-
   });
 
-  describe("setLocalIdentifier", () => {
+  describe('setLocalIdentifier', () => {
     beforeEach(function () {
       delete process.env.BROWSERSTACK_LOCAL_IDENTIFIER;
     });
@@ -570,41 +638,44 @@ describe("utils", () => {
     afterEach(function () {
       delete process.env.BROWSERSTACK_LOCAL_IDENTIFIER;
     });
-    it("should not change local identifier in bsConfig if process.env.BROWSERSTACK_LOCAL_IDENTIFIER is undefined", () => {
+    it('should not change local identifier in bsConfig if process.env.BROWSERSTACK_LOCAL_IDENTIFIER is undefined', () => {
       let bsConfig = {
         connection_settings: {
-          local_identifier: "local_identifier"
-        }
-      }
+          local_identifier: 'local_identifier',
+        },
+      };
       utils.setLocalIdentifier(bsConfig);
-      expect(bsConfig.connection_settings.local_identifier).to.be.eq("local_identifier");
+      expect(bsConfig.connection_settings.local_identifier).to.be.eq(
+        'local_identifier'
+      );
     });
 
-    it("should change local identifier to local_identifier in bsConfig if process.env.BROWSERSTACK_LOCAL_IDENTIFIER is set to local_identifier", () => {
+    it('should change local identifier to local_identifier in bsConfig if process.env.BROWSERSTACK_LOCAL_IDENTIFIER is set to local_identifier', () => {
       let bsConfig = {
         connection_settings: {
-          local_identifier: "test"
-        }
-      }
-      process.env.BROWSERSTACK_LOCAL_IDENTIFIER = "local_identifier";
+          local_identifier: 'test',
+        },
+      };
+      process.env.BROWSERSTACK_LOCAL_IDENTIFIER = 'local_identifier';
       utils.setLocalIdentifier(bsConfig);
-      expect(bsConfig.connection_settings.local_identifier).to.be.eq("local_identifier");
+      expect(bsConfig.connection_settings.local_identifier).to.be.eq(
+        'local_identifier'
+      );
     });
 
-    it("should set local identifier in connection_settings in bsConfig if process.env.BROWSERSTACK_LOCAL_IDENTIFIER is present & not set in bsConfig", () => {
+    it('should set local identifier in connection_settings in bsConfig if process.env.BROWSERSTACK_LOCAL_IDENTIFIER is present & not set in bsConfig', () => {
       let bsConfig = {
-        connection_settings: {
-        }
-      }
-      process.env.BROWSERSTACK_LOCAL_IDENTIFIER = "local_identifier";
+        connection_settings: {},
+      };
+      process.env.BROWSERSTACK_LOCAL_IDENTIFIER = 'local_identifier';
       utils.setLocalIdentifier(bsConfig);
-      expect(bsConfig.connection_settings.local_identifier).to.be.eq("local_identifier");
+      expect(bsConfig.connection_settings.local_identifier).to.be.eq(
+        'local_identifier'
+      );
     });
-
   });
 
-  describe("setUsername", () => {
-
+  describe('setUsername', () => {
     beforeEach(function () {
       delete process.env.BROWSERSTACK_USERNAME;
     });
@@ -613,40 +684,39 @@ describe("utils", () => {
       delete process.env.BROWSERSTACK_USERNAME;
     });
 
-    it("should set username if args.username is present", () => {
+    it('should set username if args.username is present', () => {
       let bsConfig = {
         auth: {
-          username: "test"
-        }
-      }
-      utils.setUsername(bsConfig, { username: "username" });
-      expect(bsConfig.auth.username).to.be.eq("username");
+          username: 'test',
+        },
+      };
+      utils.setUsername(bsConfig, {username: 'username'});
+      expect(bsConfig.auth.username).to.be.eq('username');
     });
 
-    it("should set username if process.env.BROWSERSTACK_USERNAME is present and args.username is not present", () => {
+    it('should set username if process.env.BROWSERSTACK_USERNAME is present and args.username is not present', () => {
       let bsConfig = {
         auth: {
-          username: "test"
-        }
-      }
-      process.env.BROWSERSTACK_USERNAME = "username"
+          username: 'test',
+        },
+      };
+      process.env.BROWSERSTACK_USERNAME = 'username';
       utils.setUsername(bsConfig, {});
-      expect(bsConfig.auth.username).to.be.eq("username");
+      expect(bsConfig.auth.username).to.be.eq('username');
     });
 
-    it("should set username to default if process.env.BROWSERSTACK_USERNAME and args.username is not present", () => {
+    it('should set username to default if process.env.BROWSERSTACK_USERNAME and args.username is not present', () => {
       let bsConfig = {
         auth: {
-          username: "test"
-        }
-      }
+          username: 'test',
+        },
+      };
       utils.setUsername(bsConfig, {});
-      expect(bsConfig.auth.username).to.be.eq("test");
+      expect(bsConfig.auth.username).to.be.eq('test');
     });
-
   });
 
-  describe("setAccessKey", () => {
+  describe('setAccessKey', () => {
     beforeEach(function () {
       delete process.env.BROWSERSTACK_ACCESS_KEY;
     });
@@ -655,158 +725,225 @@ describe("utils", () => {
       delete process.env.BROWSERSTACK_ACCESS_KEY;
     });
 
-    it("should set access_key if args.key is present", () => {
+    it('should set access_key if args.key is present', () => {
       let bsConfig = {
         auth: {
-          access_key: "test"
-        }
-      }
-      utils.setAccessKey(bsConfig, { key: "access_key" });
-      expect(bsConfig.auth.access_key).to.be.eq("access_key");
+          access_key: 'test',
+        },
+      };
+      utils.setAccessKey(bsConfig, {key: 'access_key'});
+      expect(bsConfig.auth.access_key).to.be.eq('access_key');
     });
 
-    it("should set access_key if process.env.BROWSERSTACK_ACCESS_KEY is present and args.access_key is not present", () => {
+    it('should set access_key if process.env.BROWSERSTACK_ACCESS_KEY is present and args.access_key is not present', () => {
       let bsConfig = {
         auth: {
-          access_key: "test"
-        }
-      }
-      process.env.BROWSERSTACK_ACCESS_KEY = "access_key"
+          access_key: 'test',
+        },
+      };
+      process.env.BROWSERSTACK_ACCESS_KEY = 'access_key';
       utils.setAccessKey(bsConfig, {});
-      expect(bsConfig.auth.access_key).to.be.eq("access_key");
+      expect(bsConfig.auth.access_key).to.be.eq('access_key');
     });
 
-    it("should set access_key to default if process.env.BROWSERSTACK_ACCESS_KEY and args.access_key is not present", () => {
+    it('should set access_key to default if process.env.BROWSERSTACK_ACCESS_KEY and args.access_key is not present', () => {
       let bsConfig = {
         auth: {
-          access_key: "test"
-        }
-      }
+          access_key: 'test',
+        },
+      };
       utils.setAccessKey(bsConfig, {});
-      expect(bsConfig.auth.access_key).to.be.eq("test");
+      expect(bsConfig.auth.access_key).to.be.eq('test');
     });
-
   });
 
-  describe("verifyCypressConfigFileOption", () => {
+  describe('verifyCypressConfigFileOption', () => {
     let utilsearchForOptionCypressConfigFileStub, userOption, testOption;
 
-    beforeEach(function() {
+    beforeEach(function () {
       utilsearchForOptionCypressConfigFileStub = sinon
-                                                    .stub(utils, 'searchForOption')
-                                                    .callsFake((...userOption) => {
-                                                      return (userOption == testOption);
-                                                    });
+        .stub(utils, 'searchForOption')
+        .callsFake((...userOption) => {
+          return userOption == testOption;
+        });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       utilsearchForOptionCypressConfigFileStub.restore();
     });
 
-    it("-ccf user option", () => {
+    it('-ccf user option', () => {
       testOption = '-ccf';
       expect(utils.verifyCypressConfigFileOption()).to.be.true;
-      sinon.assert.calledWithExactly(utilsearchForOptionCypressConfigFileStub, testOption);
+      sinon.assert.calledWithExactly(
+        utilsearchForOptionCypressConfigFileStub,
+        testOption
+      );
     });
 
-    it("--ccf user option", () => {
+    it('--ccf user option', () => {
       testOption = '--ccf';
       expect(utils.verifyCypressConfigFileOption()).to.be.true;
-      sinon.assert.calledWithExactly(utilsearchForOptionCypressConfigFileStub, testOption);
+      sinon.assert.calledWithExactly(
+        utilsearchForOptionCypressConfigFileStub,
+        testOption
+      );
     });
 
-    it("-cypress-config-file user option", () => {
+    it('-cypress-config-file user option', () => {
       testOption = '-cypress-config-file';
       expect(utils.verifyCypressConfigFileOption()).to.be.true;
-      sinon.assert.calledWithExactly(utilsearchForOptionCypressConfigFileStub, testOption);
+      sinon.assert.calledWithExactly(
+        utilsearchForOptionCypressConfigFileStub,
+        testOption
+      );
     });
 
-    it("--cypress-config-file user option", () => {
+    it('--cypress-config-file user option', () => {
       testOption = '--cypress-config-file';
       expect(utils.verifyCypressConfigFileOption()).to.be.true;
-      sinon.assert.calledWithExactly(utilsearchForOptionCypressConfigFileStub, testOption);
+      sinon.assert.calledWithExactly(
+        utilsearchForOptionCypressConfigFileStub,
+        testOption
+      );
     });
 
-    it("-cypressConfigFile user option", () => {
+    it('-cypressConfigFile user option', () => {
       testOption = '-cypressConfigFile';
       expect(utils.verifyCypressConfigFileOption()).to.be.true;
-      sinon.assert.calledWithExactly(utilsearchForOptionCypressConfigFileStub, testOption);
+      sinon.assert.calledWithExactly(
+        utilsearchForOptionCypressConfigFileStub,
+        testOption
+      );
     });
 
-    it("--cypressConfigFile user option", () => {
+    it('--cypressConfigFile user option', () => {
       testOption = '--cypressConfigFile';
       expect(utils.verifyCypressConfigFileOption()).to.be.true;
-      sinon.assert.calledWithExactly(utilsearchForOptionCypressConfigFileStub, testOption);
+      sinon.assert.calledWithExactly(
+        utilsearchForOptionCypressConfigFileStub,
+        testOption
+      );
     });
   });
 
-  describe("setCypressConfigFilename", () => {
+  describe('setCypressConfigFilename', () => {
     let verifyCypressConfigFileOptionStub,
-        ccfBool, args, bsConfig, cypress_config_file;
+      ccfBool,
+      args,
+      bsConfig,
+      cypress_config_file;
 
-    beforeEach(function() {
+    beforeEach(function () {
       verifyCypressConfigFileOptionStub = sinon
-                                            .stub(utils, 'verifyCypressConfigFileOption')
-                                            .callsFake(() => ccfBool);
+        .stub(utils, 'verifyCypressConfigFileOption')
+        .callsFake(() => ccfBool);
 
       args = {
-        cypressConfigFile: "args_cypress_config_file"
+        cypressConfigFile: 'args_cypress_config_file',
       };
     });
 
-    it("has user provided ccf flag", () => {
+    it('has user provided ccf flag', () => {
       ccfBool = true;
 
       bsConfig = {
         run_settings: {
-          cypress_config_file: "run_settings_cypress_config_file"
-        }
+          cypress_config_file: 'run_settings_cypress_config_file',
+        },
       };
 
       utils.setCypressConfigFilename(bsConfig, args);
 
-      expect(bsConfig.run_settings.cypress_config_file).to.be.eq(args.cypressConfigFile);
-      expect(bsConfig.run_settings.cypress_config_filename).to.be.eq(path.basename(args.cypressConfigFile));
+      expect(bsConfig.run_settings.cypress_config_file).to.be.eq(
+        args.cypressConfigFile
+      );
+      expect(bsConfig.run_settings.cypress_config_filename).to.be.eq(
+        path.basename(args.cypressConfigFile)
+      );
       expect(bsConfig.run_settings.userProvidedCypessConfigFile).to.be.true;
-      expect(bsConfig.run_settings.cypressConfigFilePath).to.be.eq(bsConfig.run_settings.cypress_config_file);
+      expect(bsConfig.run_settings.cypressConfigFilePath).to.be.eq(
+        bsConfig.run_settings.cypress_config_file
+      );
     });
 
-    it("does not have user provided ccf flag, sets the value from cypress_proj_dir", () => {
+    it('does not have user provided ccf flag, sets the value from cypress_proj_dir', () => {
       ccfBool = false;
 
       bsConfig = {
         run_settings: {
-          cypress_proj_dir: "cypress_proj_dir"
-        }
+          cypress_proj_dir: 'cypress_proj_dir',
+        },
       };
 
       utils.setCypressConfigFilename(bsConfig, args);
 
-      expect(bsConfig.run_settings.cypress_config_file).to.be.eq(args.cypressConfigFile);
-      expect(bsConfig.run_settings.cypress_config_filename).to.be.eq(path.basename(args.cypressConfigFile));
+      expect(bsConfig.run_settings.cypress_config_file).to.be.eq(
+        args.cypressConfigFile
+      );
+      expect(bsConfig.run_settings.cypress_config_filename).to.be.eq(
+        path.basename(args.cypressConfigFile)
+      );
       expect(bsConfig.run_settings.userProvidedCypessConfigFile).to.be.false;
-      expect(bsConfig.run_settings.cypressConfigFilePath).to.be.eq(path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json'));
+      expect(bsConfig.run_settings.cypressConfigFilePath).to.be.eq(
+        path.join(bsConfig.run_settings.cypress_proj_dir, 'cypress.json')
+      );
     });
 
-    it("does not have user provided ccf flag, sets from config file", () => {
-      cypress_config_file = "run_settings_cypress_config_file";
+    it('does not have user provided ccf flag, sets from config file', () => {
+      cypress_config_file = 'run_settings_cypress_config_file';
       ccfBool = false;
       bsConfig = {
         run_settings: {
-          cypress_config_file: cypress_config_file
-        }
+          cypress_config_file: cypress_config_file,
+        },
       };
 
       utils.setCypressConfigFilename(bsConfig, args);
 
-      expect(bsConfig.run_settings.cypress_config_file).to.be.eq(cypress_config_file);
-      expect(bsConfig.run_settings.cypress_config_filename).to.be.eq(path.basename(cypress_config_file));
+      expect(bsConfig.run_settings.cypress_config_file).to.be.eq(
+        cypress_config_file
+      );
+      expect(bsConfig.run_settings.cypress_config_filename).to.be.eq(
+        path.basename(cypress_config_file)
+      );
       expect(bsConfig.run_settings.userProvidedCypessConfigFile).to.be.true;
-      expect(bsConfig.run_settings.cypressConfigFilePath).to.be.eq(bsConfig.run_settings.cypress_config_file);
+      expect(bsConfig.run_settings.cypressConfigFilePath).to.be.eq(
+        bsConfig.run_settings.cypress_config_file
+      );
     });
 
-    afterEach(function() {
+    afterEach(function () {
       verifyCypressConfigFileOptionStub.restore();
-    })
+    });
+  });
+
+  describe('defaultAuthHash', () => {
+    beforeEach(function () {
+      delete process.env.BROWSERSTACK_USERNAME;
+    });
+
+    afterEach(function () {
+      delete process.env.BROWSERSTACK_USERNAME;
+    });
+
+    it('should set defaultAuthHash if args.username is present', () => {
+      let bsConfig = {};
+      utils.defaultAuthHash(bsConfig, {username: 'username'});
+      expect(utils.isUndefined(bsConfig.auth)).to.be.false;
+    });
+
+    it('should set defaultAuthHash if process.env.BROWSERSTACK_USERNAME is present and args.username is not present', () => {
+      let bsConfig = {};
+      process.env.BROWSERSTACK_USERNAME = 'username';
+      utils.defaultAuthHash(bsConfig, {});
+      expect(utils.isUndefined(bsConfig.auth)).to.be.false;
+    });
+
+    it('should not set defaultAuthHash if process.env.BROWSERSTACK_USERNAME and args.username is not present', () => {
+      let bsConfig = {};
+      utils.defaultAuthHash(bsConfig, {});
+      expect(utils.isUndefined(bsConfig.auth)).to.be.true;
+    });
   });
 });

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -918,7 +918,7 @@ describe('utils', () => {
     });
   });
 
-  describe('defaultAuthHash', () => {
+  describe('setDefaultAuthHash', () => {
     beforeEach(function () {
       delete process.env.BROWSERSTACK_USERNAME;
     });
@@ -927,22 +927,22 @@ describe('utils', () => {
       delete process.env.BROWSERSTACK_USERNAME;
     });
 
-    it('should set defaultAuthHash if args.username is present', () => {
+    it('should set setDefaultAuthHash if args.username is present', () => {
       let bsConfig = {};
-      utils.defaultAuthHash(bsConfig, {username: 'username'});
+      utils.setDefaultAuthHash(bsConfig, {username: 'username'});
       expect(utils.isUndefined(bsConfig.auth)).to.be.false;
     });
 
-    it('should set defaultAuthHash if process.env.BROWSERSTACK_USERNAME is present and args.username is not present', () => {
+    it('should set setDefaultAuthHash if process.env.BROWSERSTACK_USERNAME is present and args.username is not present', () => {
       let bsConfig = {};
       process.env.BROWSERSTACK_USERNAME = 'username';
-      utils.defaultAuthHash(bsConfig, {});
+      utils.setDefaultAuthHash(bsConfig, {});
       expect(utils.isUndefined(bsConfig.auth)).to.be.false;
     });
 
-    it('should not set defaultAuthHash if process.env.BROWSERSTACK_USERNAME and args.username is not present', () => {
+    it('should not set setDefaultAuthHash if process.env.BROWSERSTACK_USERNAME and args.username is not present', () => {
       let bsConfig = {};
-      utils.defaultAuthHash(bsConfig, {});
+      utils.setDefaultAuthHash(bsConfig, {});
       expect(utils.isUndefined(bsConfig.auth)).to.be.true;
     });
   });


### PR DESCRIPTION
Fix for Missing auth Hash causes exception in browserstack-cypress cli. 