### PR TITLE
Custom reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests.zip
 package-lock.json
 .nyc_output/
 .env.*
+log/*.log

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 .nyc_output/
 .env.*
 log/*.log
+results/*

--- a/bin/commands/generateReport.js
+++ b/bin/commands/generateReport.js
@@ -5,7 +5,7 @@ const config = require("../helpers/config"),
   logger = require("../helpers/logger").winstonLogger,
   Constants = require("../helpers/constants"),
   utils = require("../helpers/utils"),
-  reportGenerator = require('../helpers/reporter-html').reporterHTML;
+  reportGenerator = require('../helpers/reporterHTML').reportGenerator;
 
 
 module.exports = function info(args) {
@@ -28,71 +28,7 @@ module.exports = function info(args) {
 
     let buildId = args._[1];
 
-    let options = {
-      url: `${config.buildUrl}${buildId}/custom_report`,
-      auth: {
-        user: bsConfig.auth.username,
-        password: bsConfig.auth.access_key,
-      },
-      rejectUnauthorized: false,
-      headers: {
-        'User-Agent': utils.getUserAgent(),
-      },
-    };
-
-    request.get(options, function (err, resp, body) {
-      let message = null;
-      let messageType = null;
-      let errorCode = null;
-      let build;
-
-      if (err) {
-        message = Constants.userMessages.BUILD_INFO_FAILED;
-        messageType = Constants.messageTypes.ERROR;
-        errorCode = 'api_failed_build_info';
-
-        logger.info(message);
-      } else {
-        try {
-          build = JSON.parse(body);
-        } catch (error) {
-          build = null;
-        }
-      }
-
-      if (resp.statusCode == 299) {
-        messageType = Constants.messageTypes.INFO;
-        errorCode = 'api_deprecated';
-
-        if (build) {
-          message = build.message;
-          logger.info(message);
-        } else {
-          message = Constants.userMessages.API_DEPRECATED;
-          logger.info(message);
-        }
-      } else if (resp.statusCode != 200) {
-        messageType = Constants.messageTypes.ERROR;
-        errorCode = 'api_failed_build_generate_report';
-
-        if (build) {
-          message = `${
-            Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>>', buildId)
-          } with error: \n${JSON.stringify(build, null, 2)}`;
-          logger.error(message);
-          if (build.message === 'Unauthorized') errorCode = 'api_auth_failed';
-        } else {
-          message = Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>>', buildId);
-          logger.error(message);
-        }
-      } else {
-        messageType = Constants.messageTypes.SUCCESS;
-        message = `Report for build: ${buildId} was successfully created.`;
-        reportGenerator(build);
-        logger.info(message);
-      }
-      utils.sendUsageReport(bsConfig, args, message, messageType, errorCode);
-    });
+    reportGenerator(bsConfig, buildId);
   }).catch(function (err) {
     logger.error(err);
     utils.setUsageReportingFlag(null, args.disableUsageReporting);

--- a/bin/commands/generateReport.js
+++ b/bin/commands/generateReport.js
@@ -11,8 +11,8 @@ module.exports = function generateReport(args) {
   let reportGenerator = reporterHTML.reportGenerator;
 
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
-    // setting setDefaultAuthHash to {} if not present and set via env variables or via args.
-    utils.setDefaultAuthHash(bsConfig, args);
+    // setting setDefaults to {} if not present and set via env variables or via args.
+    utils.setDefaults(bsConfig, args);
 
     // accept the username from command line if provided
     utils.setUsername(bsConfig, args);

--- a/bin/commands/generateReport.js
+++ b/bin/commands/generateReport.js
@@ -1,10 +1,9 @@
 'use strict';
 
-const config = require("../helpers/config"),
-  logger = require("../helpers/logger").winstonLogger,
-  Constants = require("../helpers/constants"),
-  utils = require("../helpers/utils"),
-  reporterHTML = require('../helpers/reporterHTML');
+const logger = require("../helpers/logger").winstonLogger,
+      Constants = require("../helpers/constants"),
+      utils = require("../helpers/utils"),
+      reporterHTML = require('../helpers/reporterHTML');
 
 
 module.exports = function generateReport(args) {
@@ -26,12 +25,10 @@ module.exports = function generateReport(args) {
     // set cypress config filename
     utils.setCypressConfigFilename(bsConfig, args);
 
-    let buildId = args._[1];
-
     let messageType = Constants.messageTypes.INFO;
     let errorCode = null;
 
-    reportGenerator(bsConfig, buildId);
+    reportGenerator(bsConfig, args);
     utils.sendUsageReport(bsConfig, args, 'generate-report called', messageType, errorCode);
   }).catch(function (err) {
     logger.error(err);

--- a/bin/commands/generateReport.js
+++ b/bin/commands/generateReport.js
@@ -1,15 +1,15 @@
 'use strict';
-const request = require('request');
 
 const config = require("../helpers/config"),
   logger = require("../helpers/logger").winstonLogger,
   Constants = require("../helpers/constants"),
   utils = require("../helpers/utils"),
-  reportGenerator = require('../helpers/reporterHTML').reportGenerator;
+  reporterHTML = require('../helpers/reporterHTML');
 
 
-module.exports = function info(args) {
+module.exports = function generateReport(args) {
   let bsConfigPath = utils.getConfigPath(args.cf);
+  let reportGenerator = reporterHTML.reportGenerator;
 
   return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
     // setting setDefaultAuthHash to {} if not present and set via env variables or via args.
@@ -28,7 +28,11 @@ module.exports = function info(args) {
 
     let buildId = args._[1];
 
+    let messageType = Constants.messageTypes.INFO;
+    let errorCode = null;
+
     reportGenerator(bsConfig, buildId);
+    utils.sendUsageReport(bsConfig, args, 'generate-report called', messageType, errorCode);
   }).catch(function (err) {
     logger.error(err);
     utils.setUsageReportingFlag(null, args.disableUsageReporting);

--- a/bin/commands/generateReport.js
+++ b/bin/commands/generateReport.js
@@ -27,8 +27,9 @@ module.exports = function generateReport(args) {
 
     let messageType = Constants.messageTypes.INFO;
     let errorCode = null;
+    let buildId = args._[1];
 
-    reportGenerator(bsConfig, args);
+    reportGenerator(bsConfig, buildId, args);
     utils.sendUsageReport(bsConfig, args, 'generate-report called', messageType, errorCode);
   }).catch(function (err) {
     logger.error(err);

--- a/bin/commands/generateReport.js
+++ b/bin/commands/generateReport.js
@@ -1,0 +1,101 @@
+'use strict';
+const request = require('request');
+
+const config = require("../helpers/config"),
+  logger = require("../helpers/logger").winstonLogger,
+  Constants = require("../helpers/constants"),
+  utils = require("../helpers/utils"),
+  reportGenerator = require('../helpers/reporter-html').reporterHTML;
+
+
+module.exports = function info(args) {
+  let bsConfigPath = utils.getConfigPath(args.cf);
+
+  return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
+    // setting setDefaultAuthHash to {} if not present and set via env variables or via args.
+    utils.setDefaultAuthHash(bsConfig, args);
+
+    // accept the username from command line if provided
+    utils.setUsername(bsConfig, args);
+
+    // accept the access key from command line if provided
+    utils.setAccessKey(bsConfig, args);
+
+    utils.setUsageReportingFlag(bsConfig, args.disableUsageReporting);
+
+    // set cypress config filename
+    utils.setCypressConfigFilename(bsConfig, args);
+
+    let buildId = args._[1];
+
+    let options = {
+      url: `${config.buildUrl}${buildId}/custom_report`,
+      auth: {
+        user: bsConfig.auth.username,
+        password: bsConfig.auth.access_key,
+      },
+      rejectUnauthorized: false,
+      headers: {
+        'User-Agent': utils.getUserAgent(),
+      },
+    };
+
+    request.get(options, function (err, resp, body) {
+      let message = null;
+      let messageType = null;
+      let errorCode = null;
+      let build;
+
+      if (err) {
+        message = Constants.userMessages.BUILD_INFO_FAILED;
+        messageType = Constants.messageTypes.ERROR;
+        errorCode = 'api_failed_build_info';
+
+        logger.info(message);
+      } else {
+        try {
+          build = JSON.parse(body);
+        } catch (error) {
+          build = null;
+        }
+      }
+
+      if (resp.statusCode == 299) {
+        messageType = Constants.messageTypes.INFO;
+        errorCode = 'api_deprecated';
+
+        if (build) {
+          message = build.message;
+          logger.info(message);
+        } else {
+          message = Constants.userMessages.API_DEPRECATED;
+          logger.info(message);
+        }
+      } else if (resp.statusCode != 200) {
+        messageType = Constants.messageTypes.ERROR;
+        errorCode = 'api_failed_build_generate_report';
+
+        if (build) {
+          message = `${
+            Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>>', buildId)
+          } with error: \n${JSON.stringify(build, null, 2)}`;
+          logger.error(message);
+          if (build.message === 'Unauthorized') errorCode = 'api_auth_failed';
+        } else {
+          message = Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>>', buildId);
+          logger.error(message);
+        }
+      } else {
+        messageType = Constants.messageTypes.SUCCESS;
+        message = `Report for build: ${buildId} was successfully created.`;
+        reportGenerator(build);
+        logger.info(message);
+      }
+      utils.sendUsageReport(bsConfig, args, message, messageType, errorCode);
+    });
+  }).catch(function (err) {
+    logger.error(err);
+    utils.setUsageReportingFlag(null, args.disableUsageReporting);
+    utils.sendUsageReport(null, args, err.message, Constants.messageTypes.ERROR, utils.getErrorCodeFromErr(err));
+  });
+};

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -8,7 +8,8 @@ const archiver = require("../helpers/archiver"),
   Constants = require("../helpers/constants"),
   utils = require("../helpers/utils"),
   fileHelpers = require("../helpers/fileHelpers"),
-  syncRunner = require("../helpers/syncRunner");
+  syncRunner = require("../helpers/syncRunner"),
+  reporterHTML = require('../helpers/reporterHTML');
 
 module.exports = function run(args) {
   let bsConfigPath = utils.getConfigPath(args.cf);
@@ -73,6 +74,8 @@ module.exports = function run(args) {
                 utils.sendUsageReport(bsConfig, args, `${message}\n${dashboardLink}`, Constants.messageTypes.SUCCESS, null);
                 utils.handleSyncExit(exitCode, data.dashboard_url)
               });
+              // Generate custom report!
+              reporterHTML.reportGenerator(bsConfig, data.build_id, args);
             }
 
             logger.info(message);

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -72,10 +72,10 @@ module.exports = function run(args) {
             if (args.sync) {
               syncRunner.pollBuildStatus(bsConfig, data).then((exitCode) => {
                 utils.sendUsageReport(bsConfig, args, `${message}\n${dashboardLink}`, Constants.messageTypes.SUCCESS, null);
+                // Generate custom report!
+                reporterHTML.reportGenerator(bsConfig, data.build_id, args);
                 utils.handleSyncExit(exitCode, data.dashboard_url)
               });
-              // Generate custom report!
-              reporterHTML.reportGenerator(bsConfig, data.build_id, args);
             }
 
             logger.info(message);

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -9,7 +9,7 @@ const archiver = require("../helpers/archiver"),
   utils = require("../helpers/utils"),
   fileHelpers = require("../helpers/fileHelpers"),
   syncRunner = require("../helpers/syncRunner"),
-  reporterHTML = require('../helpers/reporterHTML');
+  reportGenerator = require('../helpers/reporterHTML').reportGenerator;
 
 module.exports = function run(args) {
   let bsConfigPath = utils.getConfigPath(args.cf);
@@ -71,10 +71,11 @@ module.exports = function run(args) {
             }
             if (args.sync) {
               syncRunner.pollBuildStatus(bsConfig, data).then((exitCode) => {
-                utils.sendUsageReport(bsConfig, args, `${message}\n${dashboardLink}`, Constants.messageTypes.SUCCESS, null);
                 // Generate custom report!
-                reporterHTML.reportGenerator(bsConfig, data.build_id, args);
-                utils.handleSyncExit(exitCode, data.dashboard_url)
+                reportGenerator(bsConfig, data.build_id, args, function(){
+                  utils.sendUsageReport(bsConfig, args, `${message}\n${dashboardLink}`, Constants.messageTypes.SUCCESS, null);
+                  utils.handleSyncExit(exitCode, data.dashboard_url);
+                });
               });
             }
 

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -75,6 +75,9 @@ const cliMessages = {
       USERNAME: "Your BrowserStack username",
       ACCESS_KEY: "Your BrowserStack access key",
       NO_NPM_WARNING: "No NPM warning if npm_dependencies is empty"
+    },
+    GENERATE_REPORT: {
+      INFO: "Generates the build report"
     }
 }
 

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -1,5 +1,6 @@
 const userMessages = {
     BUILD_FAILED: "Build creation failed.",
+    BUILD_GENERATE_REPORT_FAILED: "Generating report for the build <build-id> failed.",
     BUILD_CREATED: "Build created",
     BUILD_INFO_FAILED: "Failed to get build info.",
     BUILD_STOP_FAILED: "Failed to stop build.",

--- a/bin/helpers/reporter-html.js
+++ b/bin/helpers/reporter-html.js
@@ -1,0 +1,26 @@
+let templatesDir = path.join('..', 'templates');
+
+function loadFile(fileName) {
+  return fs.readFileSync(fileName, 'utf8');
+}
+
+function loadInlineCss() {
+  loadFile(path.join(templatesDir, 'browserstack-cypress-report.css'));
+}
+
+renderReportHTML = (props) => {
+  let metaCharSet = `<meta charset="utf-8">`;
+  let metaViewPort = `<meta name="viewport" content="width=device-width, initial-scale=1"> `;
+  let pageTitle = `<title> Browserstack Cypress Report </title>`;
+  let jQueryScriptTag = `<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>`;
+  let inlineCss = loadInlineCss();
+  let head = `<head> ${metaCharSet} ${metaViewPort} ${pageTitle} ${jQueryScriptTag} ${inlineCss} </head>`;
+  let htmlOpenTag = `<!DOCTYPE HTML><html>`;
+  let htmlClosetag = `</html>`;
+  let body = ``;
+  let html = `${htmlOpenTag} ${head} ${body} ${htmlClosetag}`;
+
+  return html;
+}
+
+exports.module = renderReportHTML;

--- a/bin/helpers/reporter-html.js
+++ b/bin/helpers/reporter-html.js
@@ -1,26 +1,110 @@
-let templatesDir = path.join('..', 'templates');
+const fs = require('fs'),
+      path = require('path'),
+      { winstonLogger } = require('./logger');
+
+let templatesDir = path.join(__dirname, '../', 'templates');
+
+function loadInlineCss() {
+  return loadFile(path.join(templatesDir, 'assets', 'browserstack-cypress-report.css'));
+}
 
 function loadFile(fileName) {
   return fs.readFileSync(fileName, 'utf8');
 }
 
-function loadInlineCss() {
-  loadFile(path.join(templatesDir, 'assets', 'browserstack-cypress-report.css'));
+function createBodyBuildHeader(report_data){
+  let projectNameSpan = `<span class='project-name'> ${report_data.project_name} </span>`;
+  let buildNameSpan = `<span class='build-name'> ${report_data.build_name} </span>`;
+  let buildMeta = `<div class='build-meta'> ${buildNameSpan} ${projectNameSpan} </div>`;
+  let buildLink = `<div class='build-link'> <a href='${report_data.build_url}' rel='noreferrer noopener' target='_blank'> View on BrowserStack </a> </div>`;
+  let buildHeader = `<div class='build-header'> ${buildMeta} ${buildLink} </div>`;
+  return buildHeader;
 }
 
-renderReportHTML = (props) => {
+function createBodyBuildTable(report_data) {
+  let specs = Object.keys(report_data.rows),
+      specRow = '',
+      specSessions = '',
+      sessionBlocks = '',
+      specData,
+      specNameSpan,
+      specPathSpan,
+      specStats,
+      specStatsSpan,
+      specMeta,
+      sessionStatus,
+      sessionClass,
+      sessionStatusIcon,
+      sessionLink;
+
+  specs.forEach((specName) => {
+    specData = report_data.rows[specName];
+
+    specNameSpan = `<span class='spec-name'> ${specName} </span>`;
+    specPathSpan = `<span class='spec-path'> ${specData.path} </span>`;
+
+    specStats = buildSpecStats(specData.meta);
+    specStatsSpan = `<span class='spec-stats ${specStats.cssClass}'> ${specStats.label} </span>`;
+
+    specMeta = `<div class='spec-meta'> ${specNameSpan} ${specPathSpan} ${specStatsSpan} </div>`;
+    sessionBlocks = '';
+    specData.sessions.forEach((specSession) => {
+
+      sessionStatus = specSession.status;
+      sessionClass = sessionStatus === 'passed' ? 'session-passed' : 'session-failed';
+      sessionStatusIcon = sessionStatus === 'passed' ? "&#10004; " : "&#x2717; ";
+
+      sessionLink = `<a href="${specSession.link}" rel="noreferrer noopener" target="_blank"> ${sessionStatusIcon} ${specSession.name} </a>`;
+
+      sessionDetail = `<div class="session-detail ${sessionClass}"> ${sessionLink} </div>`;
+      sessionBlocks = `${sessionBlocks} ${sessionDetail}`;
+    });
+    specSessions = `<div class='spec-sessions'> ${sessionBlocks} </div>`;
+    specRow = `${specRow} <div class='spec-row'> ${specMeta} ${specSessions} </div>`;
+  });
+
+
+  return `<div class='build-table'> ${specRow} </div>`;
+}
+
+function buildSpecStats(specMeta) {
+  let failedSpecs = specMeta.failed,
+      passedSpecs = specMeta.passed,
+      totalSpecs = specMeta.total,
+      specStats = {};
+
+  if (failedSpecs) {
+    specStats.label = `${failedSpecs}/${totalSpecs} FAILED`;
+    specStats.cssClass = 'spec-stats-failed';
+  } else {
+    specStats.label = `${passedSpecs}/${totalSpecs} PASSED`;
+    specStats.cssClass = 'spec-stats-passed';
+  }
+
+  return specStats;
+}
+
+renderReportHTML = (report_data) => {
   let metaCharSet = `<meta charset="utf-8">`;
   let metaViewPort = `<meta name="viewport" content="width=device-width, initial-scale=1"> `;
   let pageTitle = `<title> Browserstack Cypress Report </title>`;
-  let jQueryScriptTag = `<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>`;
-  let inlineCss = loadInlineCss();
-  let head = `<head> ${metaCharSet} ${metaViewPort} ${pageTitle} ${jQueryScriptTag} ${inlineCss} </head>`;
+  let inlineCss = `<style type="text/css"> ${loadInlineCss()} </style>`;
+  let head = `<head> ${metaCharSet} ${metaViewPort} ${pageTitle} ${inlineCss} </head>`;
   let htmlOpenTag = `<!DOCTYPE HTML><html>`;
   let htmlClosetag = `</html>`;
-  let body = ``;
+  let bodyBuildHeader = createBodyBuildHeader(report_data);
+  let bodyBuildTable = createBodyBuildTable(report_data);
+  let bodyReporterContainer = `<div class='report-container'> ${bodyBuildHeader} ${bodyBuildTable} </div>`;
+  let body = `<body> ${bodyReporterContainer} </body>`;
   let html = `${htmlOpenTag} ${head} ${body} ${htmlClosetag}`;
 
-  return html;
+  fs.writeFileSync('browserstack-report.html', html, () => {
+    if(err) {
+      return winstonLogger(err);
+    }
+    winstonLogger("The file was saved!");
+  });
 }
 
-exports.module = renderReportHTML;
+exports.reporterHTML = renderReportHTML;
+exports.loadInlineCss = loadInlineCss;

--- a/bin/helpers/reporter-html.js
+++ b/bin/helpers/reporter-html.js
@@ -5,7 +5,7 @@ function loadFile(fileName) {
 }
 
 function loadInlineCss() {
-  loadFile(path.join(templatesDir, 'browserstack-cypress-report.css'));
+  loadFile(path.join(templatesDir, 'assets', 'browserstack-cypress-report.css'));
 }
 
 renderReportHTML = (props) => {

--- a/bin/helpers/reporter-html.js
+++ b/bin/helpers/reporter-html.js
@@ -99,7 +99,7 @@ renderReportHTML = (report_data) => {
   let html = `${htmlOpenTag} ${head} ${body} ${htmlClosetag}`;
 
   // Writing the JSON used in creating the HTML file.
-  fs.writeFileSync('browserstack-report.json', JSON.stringify(report_data), () => {
+  fs.writeFileSync('browserstack-cypress-report.json', JSON.stringify(report_data), () => {
     if(err) {
       return logger.error(err);
     }
@@ -107,7 +107,7 @@ renderReportHTML = (report_data) => {
   });
 
   // Writing the HTML file generated from the JSON data.
-  fs.writeFileSync('browserstack-report.html', html, () => {
+  fs.writeFileSync('browserstack-cypress-report.html', html, () => {
     if(err) {
       return logger.error(err);
     }

--- a/bin/helpers/reporter-html.js
+++ b/bin/helpers/reporter-html.js
@@ -1,6 +1,6 @@
 const fs = require('fs'),
       path = require('path'),
-      { winstonLogger } = require('./logger');
+      logger = require('./logger').winstonLogger;
 
 let templatesDir = path.join(__dirname, '../', 'templates');
 
@@ -98,11 +98,20 @@ renderReportHTML = (report_data) => {
   let body = `<body> ${bodyReporterContainer} </body>`;
   let html = `${htmlOpenTag} ${head} ${body} ${htmlClosetag}`;
 
+  // Writing the JSON used in creating the HTML file.
+  fs.writeFileSync('browserstack-report.json', JSON.stringify(report_data), () => {
+    if(err) {
+      return logger.error(err);
+    }
+    logger.info("The JSON file is saved");
+  });
+
+  // Writing the HTML file generated from the JSON data.
   fs.writeFileSync('browserstack-report.html', html, () => {
     if(err) {
-      return winstonLogger(err);
+      return logger.error(err);
     }
-    winstonLogger("The file was saved!");
+    logger.info("The HTML file was saved!");
   });
 }
 

--- a/bin/helpers/reporter-html.js
+++ b/bin/helpers/reporter-html.js
@@ -85,6 +85,7 @@ function buildSpecStats(specMeta) {
 }
 
 renderReportHTML = (report_data) => {
+  let resultsDir = 'results';
   let metaCharSet = `<meta charset="utf-8">`;
   let metaViewPort = `<meta name="viewport" content="width=device-width, initial-scale=1"> `;
   let pageTitle = `<title> Browserstack Cypress Report </title>`;
@@ -98,8 +99,13 @@ renderReportHTML = (report_data) => {
   let body = `<body> ${bodyReporterContainer} </body>`;
   let html = `${htmlOpenTag} ${head} ${body} ${htmlClosetag}`;
 
+
+  if (!fs.existsSync(resultsDir)){
+    fs.mkdirSync(resultsDir);
+  }
+
   // Writing the JSON used in creating the HTML file.
-  fs.writeFileSync('browserstack-cypress-report.json', JSON.stringify(report_data), () => {
+  fs.writeFileSync(`${resultsDir}/browserstack-cypress-report.json`, JSON.stringify(report_data), () => {
     if(err) {
       return logger.error(err);
     }
@@ -107,7 +113,7 @@ renderReportHTML = (report_data) => {
   });
 
   // Writing the HTML file generated from the JSON data.
-  fs.writeFileSync('browserstack-cypress-report.html', html, () => {
+  fs.writeFileSync(`${resultsDir}/browserstack-cypress-report.html`, html, () => {
     if(err) {
       return logger.error(err);
     }

--- a/bin/helpers/reporter-html.js
+++ b/bin/helpers/reporter-html.js
@@ -107,4 +107,3 @@ renderReportHTML = (report_data) => {
 }
 
 exports.reporterHTML = renderReportHTML;
-exports.loadInlineCss = loadInlineCss;

--- a/bin/helpers/reporterHTML.js
+++ b/bin/helpers/reporterHTML.js
@@ -88,7 +88,7 @@ function buildSpecStats(specMeta) {
   return specStats;
 }
 
-let reportGenerator = (bsConfig, buildId, args) => {
+let reportGenerator = (bsConfig, buildId, args, cb) => {
   let options = {
     url: `${config.buildUrl}${buildId}/custom_report`,
     auth: {
@@ -100,7 +100,7 @@ let reportGenerator = (bsConfig, buildId, args) => {
     },
   };
 
-  request.get(options, function (err, resp, body) {
+  return request.get(options, function (err, resp, body) {
     let message = null;
     let messageType = null;
     let errorCode = null;
@@ -152,8 +152,10 @@ let reportGenerator = (bsConfig, buildId, args) => {
       logger.info(message);
     }
     utils.sendUsageReport(bsConfig, args, message, messageType, errorCode);
+    if (cb){
+      cb();
+    }
   });
-
 }
 
 function renderReportHTML(report_data) {

--- a/bin/helpers/reporterHTML.js
+++ b/bin/helpers/reporterHTML.js
@@ -95,7 +95,6 @@ let reportGenerator = (bsConfig, buildId, args) => {
       user: bsConfig.auth.username,
       password: bsConfig.auth.access_key,
     },
-    rejectUnauthorized: false,
     headers: {
       'User-Agent': utils.getUserAgent(),
     },

--- a/bin/helpers/reporterHTML.js
+++ b/bin/helpers/reporterHTML.js
@@ -137,12 +137,12 @@ let reportGenerator = (bsConfig, buildId, args, cb) => {
 
       if (build) {
         message = `${
-          Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>>', buildId)
+          Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>', buildId)
         } with error: \n${JSON.stringify(build, null, 2)}`;
         logger.error(message);
         if (build.message === 'Unauthorized') errorCode = 'api_auth_failed';
       } else {
-        message = Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>>', buildId);
+        message = Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>', buildId);
         logger.error(message);
       }
     } else {

--- a/bin/helpers/reporterHTML.js
+++ b/bin/helpers/reporterHTML.js
@@ -1,5 +1,6 @@
 const fs = require('fs'),
       path = require('path'),
+      request = require('request'),
       logger = require('./logger').winstonLogger,
       utils = require("./utils"),
       Constants = require('./constants'),
@@ -87,7 +88,7 @@ function buildSpecStats(specMeta) {
   return specStats;
 }
 
-reportGenerator = (bsConfig, buildId, args) => {
+let reportGenerator = (bsConfig, buildId, args) => {
   let options = {
     url: `${config.buildUrl}${buildId}/custom_report`,
     auth: {

--- a/bin/helpers/reporterHTML.js
+++ b/bin/helpers/reporterHTML.js
@@ -1,6 +1,9 @@
 const fs = require('fs'),
       path = require('path'),
-      logger = require('./logger').winstonLogger;
+      logger = require('./logger').winstonLogger,
+      utils = require("./utils"),
+      Constants = require('./constants'),
+      config = require("./config");
 
 let templatesDir = path.join(__dirname, '../', 'templates');
 
@@ -84,7 +87,7 @@ function buildSpecStats(specMeta) {
   return specStats;
 }
 
-reportGenerator = (bsConfig, buildId) => {
+reportGenerator = (bsConfig, buildId, args) => {
   let options = {
     url: `${config.buildUrl}${buildId}/custom_report`,
     auth: {

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -204,6 +204,46 @@ var argv = yargs
       return require('./commands/runs')(argv);
     }
   })
+  .command('generate-report', Constants.cliMessages.GENERATE_REPORT.INFO, function(yargs) {
+    argv = yargs
+      .usage('usage: $0 generate-report <buildId>')
+      .demand(1, Constants.cliMessages.BUILD.DEMAND)
+      .options({
+        'cf': {
+          alias: 'config-file',
+          describe: Constants.cliMessages.BUILD.DESC,
+          default: 'browserstack.json',
+          type: 'string',
+          nargs: 1,
+          demand: true,
+          demand: Constants.cliMessages.BUILD.CONFIG_DEMAND
+        },
+        'disable-usage-reporting': {
+          default: undefined,
+          description: Constants.cliMessages.COMMON.DISABLE_USAGE_REPORTING,
+          type: "boolean"
+        },
+        'u': {
+          alias: 'username',
+          describe: Constants.cliMessages.COMMON.USERNAME,
+          type: "string",
+          default: undefined
+        },
+        'k': {
+          alias: 'key',
+          describe: Constants.cliMessages.COMMON.ACCESS_KEY,
+          type: "string",
+          default: undefined
+        },
+      })
+      .help('help')
+      .wrap(null)
+      .argv
+    if (checkCommands(yargs, argv, 1)) {
+      logger.info(Constants.cliMessages.BUILD.INFO_MESSAGE + argv._[1]);
+      return require('./commands/info')(argv);
+    }
+  })
   .help('help')
   .wrap(null)
   .argv

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -241,7 +241,7 @@ var argv = yargs
       .argv
     if (checkCommands(yargs, argv, 1)) {
       logger.info(Constants.cliMessages.BUILD.INFO_MESSAGE + argv._[1]);
-      return require('./commands/info')(argv);
+      return require('./commands/generateReport')(argv);
     }
   })
   .help('help')

--- a/bin/templates/assets/browserstack-cypress-report.css
+++ b/bin/templates/assets/browserstack-cypress-report.css
@@ -1,0 +1,104 @@
+.report-container {
+  font-family: HelveticaNeue;
+  width: 80%;
+  margin: 0 auto;
+  margin-top: 8px;
+  border: solid 1px #dddddd;
+  background-color: #f7f7f7;
+}
+.build-header {
+  padding: 10px 16px;
+  display: flex;
+  background-color: #f7f7f7;
+  border: solid 1px #ddd;
+}
+.build-meta {
+  flex-grow: 1;
+  flex-direction: column;
+  display: flex;
+}
+.spec-meta {
+  flex-direction: column;
+  display: flex;
+  padding: 16px;
+  justify-content: center;
+  margin-right: 40px;
+}
+.build-name {
+  font-size: 18px;
+  font-weight: bold;
+  color: #333;
+}
+.project-name {
+  font-size: 12px;
+  color: #666;
+}
+.build-link {
+  display: flex;
+  align-items: center;
+}
+.build-link a {
+  cursor: pointer;
+  font-size: 12px;
+  color: #009cfc;
+  text-decoration: none;
+}
+.spec-row {
+  display: flex;
+  border: solid 1px #ddd;
+}
+.spec-row:nth-child(odd) {
+  background-color: #fff;
+}
+.spec-row:nth-child(even) {
+  background-color: #fbfbfb;
+}
+.spec-name {
+  font-size: 16px;
+  color: #333
+}
+.spec-path {
+  font-family: SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;
+  color: #666;
+  padding-top: 8px;
+  font-size: 12px;
+}
+.spec-stats {
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.5;
+  padding-top: 16px;
+}
+.spec-stats-failed {
+  color: #b22617;
+}
+.spec-stats-passed {
+  color: #68b300;
+}
+.spec-sessions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  padding: 12px 0;
+  height: min-content;
+}
+.session-detail {
+  padding: 8px 16px;
+  min-width: 160px;
+  max-width: 160px;
+  height: min-content;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.17;
+  letter-spacing: normal;
+  text-decoration: underline;
+}
+.session-passed a {
+  color: #68b300;
+}
+.session-failed a {
+  color: #d04536;
+}

--- a/test/unit/bin/commands/generateReport.js
+++ b/test/unit/bin/commands/generateReport.js
@@ -1,7 +1,6 @@
 const chai = require("chai"),
   chaiAsPromised = require("chai-as-promised"),
-  sinon = require('sinon'),
-  request = require('request');
+  sinon = require('sinon');
 
 const Constants = require("../../../../bin/helpers/constants"),
       logger = require("../../../../bin/helpers/logger").winstonLogger,

--- a/test/unit/bin/commands/generateReport.js
+++ b/test/unit/bin/commands/generateReport.js
@@ -4,8 +4,7 @@ const chai = require("chai"),
 
 const Constants = require("../../../../bin/helpers/constants"),
       logger = require("../../../../bin/helpers/logger").winstonLogger,
-      testObjects = require("../../support/fixtures/testObjects"),
-      reporterHTML = require('../helpers/reporterHTML');
+      testObjects = require("../../support/fixtures/testObjects");
 
 const proxyquire = require("proxyquire").noCallThru();
 
@@ -67,7 +66,7 @@ describe("generateReport", () => {
 
       generateReport(args)
       .then(function (_bsConfig) {
-        sinon.assert.calledWith(reportGeneratorSpy, bsConfig, args._[1]);
+        sinon.assert.calledWith(reportGeneratorSpy, bsConfig, args);
         sinon.assert.calledOnce(getConfigPathStub);
         sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, 'generate-report called', Constants.messageTypes.INFO, null);
       })

--- a/test/unit/bin/commands/generateReport.js
+++ b/test/unit/bin/commands/generateReport.js
@@ -66,7 +66,7 @@ describe("generateReport", () => {
 
       generateReport(args)
       .then(function (_bsConfig) {
-        sinon.assert.calledWith(reportGeneratorSpy, bsConfig, args);
+        sinon.assert.calledWith(reportGeneratorSpy, bsConfig, args._[1], args);
         sinon.assert.calledOnce(getConfigPathStub);
         sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, 'generate-report called', Constants.messageTypes.INFO, null);
       })

--- a/test/unit/bin/commands/generateReport.js
+++ b/test/unit/bin/commands/generateReport.js
@@ -1,4 +1,114 @@
+const chai = require("chai"),
+  chaiAsPromised = require("chai-as-promised"),
+  sinon = require('sinon'),
+  request = require('request');
+
+const Constants = require("../../../../bin/helpers/constants"),
+      logger = require("../../../../bin/helpers/logger").winstonLogger,
+      testObjects = require("../../support/fixtures/testObjects"),
+      reporterHTML = require('../helpers/reporterHTML');
+
+const proxyquire = require("proxyquire").noCallThru();
+
+chai.use(chaiAsPromised);
+logger.transports["console.info"].silent = true;
 
 describe("generateReport", () => {
+  let args = testObjects.generateReportInputArgs;
+  let body = testObjects.buildInfoSampleBody;
+  let bsConfig = testObjects.sampleBsConfig;
 
+  describe("Calling the report generator", () => {
+    var sandbox;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+
+      getConfigPathStub = sandbox.stub();
+      validateBstackJsonStub = sandbox.stub();
+      setDefaultAuthHashStub = sandbox.stub();
+      setUsernameStub = sandbox.stub();
+      setAccessKeyStub = sandbox.stub();
+      setUsageReportingFlagStub = sandbox.stub().returns(undefined);
+      setCypressConfigFilenameStub = sandbox.stub();
+      sendUsageReportStub = sandbox.stub().callsFake(function () {
+        return "end";
+      });
+
+      reportGeneratorSpy = sandbox.spy();
+      getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
+      setDefaultsStub = sandbox.stub();
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+      sinon.restore();
+    });
+
+    it("calls the reportGenerator", () => {
+      const generateReport = proxyquire('../../../../bin/commands/generateReport', {
+        '../helpers/utils': {
+          getConfigPath: getConfigPathStub,
+          validateBstackJson: validateBstackJsonStub,
+          setDefaultAuthHash: setDefaultAuthHashStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
+          setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
+          sendUsageReport: sendUsageReportStub,
+          setDefaults: setDefaultsStub,
+          getErrorCodeFromErr: getErrorCodeFromErrStub
+        },
+        '../helpers/reporterHTML': {
+          reportGenerator: reportGeneratorSpy
+        }
+      });
+
+      validateBstackJsonStub.returns(Promise.resolve(bsConfig));
+
+      generateReport(args)
+      .then(function (_bsConfig) {
+        sinon.assert.calledWith(reportGeneratorSpy, bsConfig, args._[1]);
+        sinon.assert.calledOnce(getConfigPathStub);
+        sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, 'generate-report called', Constants.messageTypes.INFO, null);
+      })
+      .catch((error) => {
+        chai.assert.isNotOk(error, 'Promise error');
+      });
+    });
+
+    it("logs and send usage report on rejection", () => {
+      const generateReport = proxyquire('../../../../bin/commands/generateReport', {
+        '../helpers/utils': {
+          getConfigPath: getConfigPathStub,
+          validateBstackJson: validateBstackJsonStub,
+          setDefaultAuthHash: setDefaultAuthHashStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
+          setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
+          sendUsageReport: sendUsageReportStub,
+          setDefaults: setDefaultsStub,
+          getErrorCodeFromErr: getErrorCodeFromErrStub
+        },
+        '../helpers/reporterHTML': {
+          reportGenerator: reportGeneratorSpy
+        }
+      });
+
+      let err = { message: "Promise error" };
+
+      validateBstackJsonStub.returns(Promise.reject(err));
+
+      generateReport(args)
+      .then(function (_bsConfig) {
+        sinon.assert.notCalled(reportGeneratorSpy);
+        sinon.assert.notCalled(getConfigPathStub);
+      })
+      .catch((_error) => {
+        sinon.assert.calledWith(setUsageReportingFlagStub, null, args.disableUsageReporting);
+        sinon.assert.calledWith(sendUsageReportStub, null, args, err.message, Constants.messageTypes.ERROR, "random-error");
+      });
+    });
+  });
 });

--- a/test/unit/bin/commands/generateReport.js
+++ b/test/unit/bin/commands/generateReport.js
@@ -1,0 +1,4 @@
+
+describe("generateReport", () => {
+
+});

--- a/test/unit/bin/helpers/reporterHTML.js
+++ b/test/unit/bin/helpers/reporterHTML.js
@@ -1,0 +1,3 @@
+
+describe("reportHTML", () => {
+});

--- a/test/unit/bin/helpers/reporterHTML.js
+++ b/test/unit/bin/helpers/reporterHTML.js
@@ -116,7 +116,7 @@ describe("reportHTML", () => {
         let body = JSON.stringify(build);
         let requestStub = sandbox.stub(request, "get").yields(null, { statusCode: 400 }, body);
         let message = `${
-          Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>>', buildId)
+          Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>', buildId)
         } with error: \n${JSON.stringify(build, null, 2)}`;
         let messageType = Constants.messageTypes.ERROR;
         let errorCode = 'api_failed_build_generate_report';
@@ -149,7 +149,7 @@ describe("reportHTML", () => {
         let body = JSON.stringify(build);
         let requestStub = sandbox.stub(request, "get").yields(null, { statusCode: 401 }, body);
         let message = `${
-          Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>>', buildId)
+          Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>', buildId)
         } with error: \n${JSON.stringify(build, null, 2)}`;
         let messageType = Constants.messageTypes.ERROR;
         let errorCode = 'api_auth_failed';
@@ -179,7 +179,7 @@ describe("reportHTML", () => {
 
       it("400 status, build not available, cannot generate report", () => {
         let requestStub = sandbox.stub(request, "get").yields(null, { statusCode: 400 }, null);
-        let message = Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>>', buildId);
+        let message = Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>', buildId);
         let messageType = Constants.messageTypes.ERROR;
         let errorCode = 'api_failed_build_generate_report';
 

--- a/test/unit/bin/helpers/reporterHTML.js
+++ b/test/unit/bin/helpers/reporterHTML.js
@@ -1,3 +1,241 @@
+const chai = require("chai"),
+  chaiAsPromised = require("chai-as-promised"),
+  sinon = require('sinon');
+
+const fs = require('fs'),
+      path = require('path'),
+      request = require('request'),
+      Constants = require("../../../../bin/helpers/constants"),
+      logger = require("../../../../bin/helpers/logger").winstonLogger,
+      testObjects = require("../../support/fixtures/testObjects");
+
+const proxyquire = require("proxyquire").noCallThru();
+
+chai.use(chaiAsPromised);
+logger.transports["console.info"].silent = true;
 
 describe("reportHTML", () => {
+  var sandbox;
+  let templateDir = 'templateDir',
+      args = testObjects.generateReportInputArgs,
+      buildId = 'buildId',
+      bsConfig = testObjects.sampleBsConfig;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    validateBstackJsonStub = sandbox.stub();
+    setDefaultAuthHashStub = sandbox.stub();
+    setUsernameStub = sandbox.stub();
+    setAccessKeyStub = sandbox.stub();
+    setUsageReportingFlagStub = sandbox.stub().returns(undefined);
+    setCypressConfigFilenameStub = sandbox.stub();
+    sendUsageReportStub = sandbox.stub().callsFake(function () {
+      return "end";
+    });
+
+    reportGeneratorSpy = sandbox.spy();
+    getErrorCodeFromErrStub = sandbox.stub().returns("random-error");
+    setDefaultsStub = sandbox.stub();
+
+    getUserAgentStub = sandbox.stub().returns("random user-agent");
+    // pathStub = sinon.stub(path, 'join').returns(templateDir);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    sinon.restore();
+    // pathStub.restore();
+  });
+
+  describe("calls API to generate report", () => {
+
+    it("is deprecated, i.e. 299, does not have build message", () => {
+      let requestStub = sandbox.stub(request, "get").yields(null, { statusCode: 299 }, null);
+      let message = Constants.userMessages.API_DEPRECATED;
+      let messageType = Constants.messageTypes.INFO;
+      let errorCode = "api_deprecated";
+
+      const reporterHTML = proxyquire('../../../../bin/helpers/reporterHTML', {
+        './utils': {
+          validateBstackJson: validateBstackJsonStub,
+          setDefaultAuthHash: setDefaultAuthHashStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
+          getUserAgent: getUserAgentStub,
+          setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
+          sendUsageReport: sendUsageReportStub,
+          setDefaults: setDefaultsStub,
+          getErrorCodeFromErr: getErrorCodeFromErrStub
+        },
+        request: {get: requestStub}
+      });
+
+      reporterHTML.reportGenerator(bsConfig, buildId, args);
+
+      sinon.assert.calledOnce(requestStub);
+      sinon.assert.calledOnce(getUserAgentStub);
+      sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, message, messageType, errorCode);
+    });
+
+    it("is deprecated, i.e. 299", () => {
+      let build = { buildId: buildId, message: 'API has been deprecated', rows: [] };
+      let body = JSON.stringify(build);
+      let requestStub = sandbox.stub(request, "get").yields(null, { statusCode: 299 }, body);
+      let message = build.message;
+      let messageType = Constants.messageTypes.INFO;
+      let errorCode = "api_deprecated";
+
+      const reporterHTML = proxyquire('../../../../bin/helpers/reporterHTML', {
+        './utils': {
+          validateBstackJson: validateBstackJsonStub,
+          setDefaultAuthHash: setDefaultAuthHashStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
+          getUserAgent: getUserAgentStub,
+          setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
+          sendUsageReport: sendUsageReportStub,
+          setDefaults: setDefaultsStub,
+          getErrorCodeFromErr: getErrorCodeFromErrStub
+        },
+        request: {get: requestStub}
+      });
+
+      reporterHTML.reportGenerator(bsConfig, buildId, args);
+
+      sinon.assert.calledOnce(requestStub);
+      sinon.assert.calledOnce(getUserAgentStub);
+      sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, message, messageType, errorCode);
+    });
+
+    context("non 200 response", () => {
+      it("400 status, build available, cannot generate report", () => {
+        let build = { buildId: buildId, message: 'success', rows: [] };
+        let body = JSON.stringify(build);
+        let requestStub = sandbox.stub(request, "get").yields(null, { statusCode: 400 }, body);
+        let message = `${
+          Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>>', buildId)
+        } with error: \n${JSON.stringify(build, null, 2)}`;
+        let messageType = Constants.messageTypes.ERROR;
+        let errorCode = 'api_failed_build_generate_report';
+
+        const reporterHTML = proxyquire('../../../../bin/helpers/reporterHTML', {
+          './utils': {
+            validateBstackJson: validateBstackJsonStub,
+            setDefaultAuthHash: setDefaultAuthHashStub,
+            setUsername: setUsernameStub,
+            setAccessKey: setAccessKeyStub,
+            getUserAgent: getUserAgentStub,
+            setUsageReportingFlag: setUsageReportingFlagStub,
+            setCypressConfigFilename: setCypressConfigFilenameStub,
+            sendUsageReport: sendUsageReportStub,
+            setDefaults: setDefaultsStub,
+            getErrorCodeFromErr: getErrorCodeFromErrStub
+          },
+          request: {get: requestStub}
+        });
+
+        reporterHTML.reportGenerator(bsConfig, buildId, args);
+
+        sinon.assert.calledOnce(requestStub);
+        sinon.assert.calledOnce(getUserAgentStub);
+        sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, message, messageType, errorCode);
+      });
+
+      it("user is unauthorized", () => {
+        let build = { buildId: buildId, message: 'Unauthorized', rows: [] };
+        let body = JSON.stringify(build);
+        let requestStub = sandbox.stub(request, "get").yields(null, { statusCode: 401 }, body);
+        let message = `${
+          Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>>', buildId)
+        } with error: \n${JSON.stringify(build, null, 2)}`;
+        let messageType = Constants.messageTypes.ERROR;
+        let errorCode = 'api_auth_failed';
+
+        const reporterHTML = proxyquire('../../../../bin/helpers/reporterHTML', {
+          './utils': {
+            validateBstackJson: validateBstackJsonStub,
+            setDefaultAuthHash: setDefaultAuthHashStub,
+            setUsername: setUsernameStub,
+            setAccessKey: setAccessKeyStub,
+            getUserAgent: getUserAgentStub,
+            setUsageReportingFlag: setUsageReportingFlagStub,
+            setCypressConfigFilename: setCypressConfigFilenameStub,
+            sendUsageReport: sendUsageReportStub,
+            setDefaults: setDefaultsStub,
+            getErrorCodeFromErr: getErrorCodeFromErrStub
+          },
+          request: {get: requestStub}
+        });
+
+        reporterHTML.reportGenerator(bsConfig, buildId, args);
+
+        sinon.assert.calledOnce(requestStub);
+        sinon.assert.calledOnce(getUserAgentStub);
+        sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, message, messageType, errorCode);
+      });
+
+      it("400 status, build not available, cannot generate report", () => {
+        let requestStub = sandbox.stub(request, "get").yields(null, { statusCode: 400 }, null);
+        let message = Constants.userMessages.BUILD_GENERATE_REPORT_FAILED.replace('<build-id>>', buildId);
+        let messageType = Constants.messageTypes.ERROR;
+        let errorCode = 'api_failed_build_generate_report';
+
+        const reporterHTML = proxyquire('../../../../bin/helpers/reporterHTML', {
+          './utils': {
+            validateBstackJson: validateBstackJsonStub,
+            setDefaultAuthHash: setDefaultAuthHashStub,
+            setUsername: setUsernameStub,
+            setAccessKey: setAccessKeyStub,
+            getUserAgent: getUserAgentStub,
+            setUsageReportingFlag: setUsageReportingFlagStub,
+            setCypressConfigFilename: setCypressConfigFilenameStub,
+            sendUsageReport: sendUsageReportStub,
+            setDefaults: setDefaultsStub,
+            getErrorCodeFromErr: getErrorCodeFromErrStub
+          },
+          request: {get: requestStub}
+        });
+
+        reporterHTML.reportGenerator(bsConfig, buildId, args);
+
+        sinon.assert.calledOnce(requestStub);
+        sinon.assert.calledOnce(getUserAgentStub);
+        sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, message, messageType, errorCode);
+      });
+    });
+
+    it("200 response code", () => {
+      let build = { buildId: buildId, message: 'success', rows: [] };
+      let body = JSON.stringify(build);
+      let requestStub = sandbox.stub(request, "get").yields(null, { statusCode: 200 }, body);
+      let message = `Report for build: ${buildId} was successfully created.`;
+      let messageType = Constants.messageTypes.SUCCESS;
+      let errorCode = null;
+
+      const reporterHTML = proxyquire('../../../../bin/helpers/reporterHTML', {
+        './utils': {
+          validateBstackJson: validateBstackJsonStub,
+          setDefaultAuthHash: setDefaultAuthHashStub,
+          setUsername: setUsernameStub,
+          setAccessKey: setAccessKeyStub,
+          getUserAgent: getUserAgentStub,
+          setUsageReportingFlag: setUsageReportingFlagStub,
+          setCypressConfigFilename: setCypressConfigFilenameStub,
+          sendUsageReport: sendUsageReportStub,
+          setDefaults: setDefaultsStub,
+          getErrorCodeFromErr: getErrorCodeFromErrStub
+        },
+        request: {get: requestStub}
+      });
+
+      reporterHTML.reportGenerator(bsConfig, buildId, args);
+
+      sinon.assert.calledOnce(requestStub);
+      sinon.assert.calledOnce(getUserAgentStub);
+      sinon.assert.calledOnceWithExactly(sendUsageReportStub, bsConfig, args, message, messageType, errorCode);
+    });
+  });
 });

--- a/test/unit/support/fixtures/testObjects.js
+++ b/test/unit/support/fixtures/testObjects.js
@@ -29,6 +29,16 @@ const buildInfoSampleArgs = {
   $0: "browserstack-cypress",
 };
 
+const generateReportInputArgs = {
+  _: ["generate-report", "f3c94f7203792d03a75be3912d19354fe0961e53"],
+  cf: "browserstack.json",
+  "config-file": "browserstack.json",
+  configFile: "browserstack.json",
+  "disable-usage-reporting": undefined,
+  disableUsageReporting: undefined,
+  $0: "browserstack-cypress",
+};
+
 const buildInfoSampleBody = {
   build_id: "random_hashed_id",
   framework: "cypress",
@@ -121,4 +131,5 @@ module.exports = Object.freeze({
   buildStopSampleBody,
   sampleCapsData,
   runSampleArgs,
+  generateReportInputArgs,
 });


### PR DESCRIPTION
This PR adds:

- Command to generate the build report: `generate-report <build-id>`
- Interface for fetching the report data in JSON from the API.
- Saving JSON and HTML file that's generated in the same directory where the command was run.
- Always generates the reports in sync CLI mode.