### PR TITLE
Show error message when build is in running state

### DIFF
--- a/bin/helpers/reporterHTML.js
+++ b/bin/helpers/reporterHTML.js
@@ -136,6 +136,8 @@ let reportGenerator = (bsConfig, buildId, args, cb) => {
         logger.info(message);
       }
     } else if (resp.statusCode === 422) {
+      messageType = Constants.messageTypes.ERROR;
+      errorCode = 'api_failed_build_generate_report';
       try {
         response = JSON.parse(body);
         message = response.message;

--- a/bin/helpers/reporterHTML.js
+++ b/bin/helpers/reporterHTML.js
@@ -112,18 +112,6 @@ let reportGenerator = (bsConfig, buildId, args, cb) => {
       errorCode = 'api_failed_build_report';
 
       logger.error('Generating the build report failed.');
-
-      if (resp.statusCode == 422) {
-        try {
-          response = JSON.parse(body);
-          message = response.message;
-        } catch (error) {
-          logger.error(`Error generating the report: ${error}`);
-          response = {message: message};
-        }
-        logger.error(response.message);
-      }
-
       logger.error(message);
 
       utils.sendUsageReport(bsConfig, args, message, messageType, errorCode);
@@ -147,6 +135,15 @@ let reportGenerator = (bsConfig, buildId, args, cb) => {
         message = Constants.userMessages.API_DEPRECATED;
         logger.info(message);
       }
+    } else if (resp.statusCode === 422) {
+      try {
+        response = JSON.parse(body);
+        message = response.message;
+      } catch (error) {
+        logger.error(`Error generating the report: ${error}`);
+        response = {message: message};
+      }
+      logger.error(response.message);
     } else if (resp.statusCode != 200) {
       messageType = Constants.messageTypes.ERROR;
       errorCode = 'api_failed_build_generate_report';

--- a/bin/helpers/reporterHTML.js
+++ b/bin/helpers/reporterHTML.js
@@ -112,6 +112,18 @@ let reportGenerator = (bsConfig, buildId, args, cb) => {
       errorCode = 'api_failed_build_report';
 
       logger.error('Generating the build report failed.');
+
+      if (resp.statusCode == 422) {
+        try {
+          response = JSON.parse(body);
+          message = response.message;
+        } catch (error) {
+          logger.error(`Error generating the report: ${error}`);
+          response = {message: message};
+        }
+        logger.error(response.message);
+      }
+
       logger.error(message);
 
       utils.sendUsageReport(bsConfig, args, message, messageType, errorCode);


### PR DESCRIPTION
In case when generate build command is fired when the build is running, this change will not show an error message instead of generating an incorrect build report.