### PR TITLE
Upgrade archiver to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,16 @@
     "browserstack-cypress": "bin/runner.js"
   },
   "dependencies": {
-    "archiver": "^3.1.1",
+    "archiver": "^5.2.0",
     "chalk": "^4.1.0",
     "fs-extra": "^8.1.0",
+    "glob": "^7.1.6",
     "mkdirp": "^1.0.3",
     "request": "^2.88.0",
     "requestretry": "^4.1.0",
     "table": "^5.4.6",
     "winston": "^2.3.1",
-    "yargs": "^14.2.2",
-    "glob": "^7.1.6"
+    "yargs": "^14.2.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Node v15+ is having issues with archiver 3.1.1, it fails to zip `cypress.json` and `browserstack-package.json` correctly, resulting in NPM installation failure and Unzip failure. This upgrade fixes it.