### PR TITLE
Wrap CSV input for --spec around with {}

### DIFF
--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -341,11 +341,15 @@ exports.setHeaded = (bsConfig, args) => {
 
 exports.getNumberOfSpecFiles = (bsConfig, args, cypressJson) => {
   let testFolderPath = cypressJson.integrationFolder || Constants.DEFAULT_CYPRESS_SPEC_PATH;
-  let globSearchPatttern = bsConfig.run_settings.specs || `${testFolderPath}/**/*.+(${Constants.specFileTypes.join("|")})`;
+  let globSearchPattern = this.sanitizeSpecsPattern(bsConfig.run_settings.specs) || `${testFolderPath}/**/*.+(${Constants.specFileTypes.join("|")})`;
   let ignoreFiles = args.exclude || bsConfig.run_settings.exclude;
-  let files = glob.sync(globSearchPatttern, {cwd: bsConfig.run_settings.cypressProjectDir, matchBase: true, ignore: ignoreFiles});
+  let files = glob.sync(globSearchPattern, {cwd: bsConfig.run_settings.cypressProjectDir, matchBase: true, ignore: ignoreFiles});
   return files;
 };
+
+exports.sanitizeSpecsPattern = (pattern) => {
+  return pattern && pattern.split(",").length > 1 ? "{" + pattern + "}" : pattern;
+}
 
 exports.getBrowserCombinations = (bsConfig) => {
   let osBrowserArray = [];

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -1099,7 +1099,7 @@ describe('utils', () => {
       expect(utils.sanitizeSpecsPattern("pattern3")).to.eq("pattern3");
     });
 
-    it('should return null when --spec is undeffined', () => {
+    it('should return null when --spec is undefined', () => {
       expect(utils.sanitizeSpecsPattern(undefined)).to.eq(undefined);
     });
   });

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -1099,7 +1099,7 @@ describe('utils', () => {
       expect(utils.sanitizeSpecsPattern("pattern3")).to.eq("pattern3");
     });
 
-    it('should return null when --spec is undefined', () => {
+    it('should return undefined when --spec is undefined', () => {
       expect(utils.sanitizeSpecsPattern(undefined)).to.eq(undefined);
     });
   });

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -1089,6 +1089,21 @@ describe('utils', () => {
 
   });
 
+  describe('sanitizeSpecsPattern', () => {
+
+    it('should wrap pattern around {} when input is csv', () => {
+      expect(utils.sanitizeSpecsPattern("pattern1,pattern2")).to.eq("{pattern1,pattern2}");
+    });
+
+    it('should not wrap pattern around {} when input is single glob pattern', () => {
+      expect(utils.sanitizeSpecsPattern("pattern3")).to.eq("pattern3");
+    });
+
+    it('should return null when --spec is undeffined', () => {
+      expect(utils.sanitizeSpecsPattern(undefined)).to.eq(undefined);
+    });
+  });
+
   describe('getBrowserCombinations', () => {
 
     it('returns correct number of browserCombinations for one combination', () => {


### PR DESCRIPTION
If a csv value is provided for --spec, it fails to detect the spec files correctly leading to incorrect parallel count calculation. This PR wraps the csv value around `{}` and if it is not csv then does nothing. 