### PR TITLE
Local mode and id validation

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -42,9 +42,6 @@ module.exports = function run(args) {
     //accept the local from env variable if provided
     utils.setLocal(bsConfig, args);
 
-    // set Local Mode (on-demand/ always-on)
-    utils.setLocalMode(bsConfig, args);
-
     //accept the local identifier from env variable if provided
     utils.setLocalIdentifier(bsConfig, args);
 
@@ -62,6 +59,9 @@ module.exports = function run(args) {
 
       // accept the number of parallels
       utils.setParallels(bsConfig, args, specFiles.length);
+
+      // set Local Mode (on-demand/ always-on)
+      utils.setLocalMode(bsConfig, args);
 
       // Archive the spec files
       return archiver.archive(bsConfig.run_settings, config.fileName, args.exclude).then(function (data) {

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -159,10 +159,8 @@ const validate = (bsConfig, args) => {
     if (!Utils.isUndefined(args) && !Utils.isUndefined(args.parallels) && !Utils.isParallelValid(args.parallels)) reject(Constants.validationMessages.INVALID_PARALLELS_CONFIGURATION);
 
     // validate local args i.e --local-mode and --local-identifier
-
-    if( Utils.searchForOption('--local-identifier') && (Utils.isUndefined(args.localIdentifier) || (!Utils.isUndefined(args.localIdentifier) && !args.localIdentifier.trim()))) reject(Constants.validationMessages.INVALID_LOCAL_IDENTIFIER);
-
-    if( Utils.searchForOption('--local-mode') && ( Utils.isUndefined(args.localMode) || (!Utils.isUndefined(args.localMode) && !["always-on","on-demand"].includes(args.localMode)))) reject(Constants.validationMessages.INVALID_LOCAL_MODE);
+    if (Utils.invalidLocalMode(bsConfig, args)) reject(Constants.validationMessages.INVALID_LOCAL_MODE);
+    if (Utils.invalidLocalIdentifier(bsConfig, args)) reject(Constants.validationMessages.INVALID_LOCAL_IDENTIFIER);
 
     if( Utils.searchForOption('--local-config-file') && ( Utils.isUndefined(args.localConfigFile) || (!Utils.isUndefined(args.localConfigFile) && !fs.existsSync(args.localConfigFile)))) reject(Constants.validationMessages.INVALID_LOCAL_CONFIG_FILE);
 

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -578,6 +578,26 @@ exports.versionChangedMessage = (preferredVersion, actualVersion) => {
   return message
 }
 
+exports.invalidLocalMode = (bsConfig, args) => {
+  let localMode = undefined;
+  if (!this.isUndefined(args.localMode)) {
+    localMode = args.localMode;
+  } else if (!this.isUndefined(bsConfig.connection_settings)) {
+    localMode = bsConfig.connection_settings.local_mode
+  }
+  return (this.searchForOption('--local-mode') || !this.isUndefined(localMode)) && !["always-on","on-demand"].includes(localMode);
+}
+
+exports.invalidLocalIdentifier = (bsConfig, args) => {
+  let localId = undefined;
+  if (this.searchForOption('--local-identifier') && !this.isUndefined(args.localIdentifier)) {
+    localId = !args.localIdentifier.toString().trim();
+  } else if (!this.isUndefined(bsConfig.connection_settings)) {
+    localId = !bsConfig.connection_settings.local_identifier.toString().trim();
+  }
+  return !!localId
+}
+
 exports.isJSONInvalid = (err, args) => {
   let invalid =  true
 

--- a/test/unit/bin/commands/runs.js
+++ b/test/unit/bin/commands/runs.js
@@ -103,7 +103,6 @@ describe("runs", () => {
       setHeadedStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
       setDefaultsStub = sandbox.stub();
-      setLocalModeStub = sandbox.stub();
       setLocalConfigFileStub = sandbox.stub();
     });
 
@@ -137,7 +136,6 @@ describe("runs", () => {
           setDefaults: setDefaultsStub,
           setupLocalTesting: setupLocalTestingStub,
           isJSONInvalid: isJSONInvalidStub,
-          setLocalMode: setLocalModeStub,
           setLocalConfigFile: setLocalConfigFileStub
         },
         '../helpers/capabilityHelper': {
@@ -166,7 +164,6 @@ describe("runs", () => {
           sinon.assert.calledOnce(setUserSpecsStub);
           sinon.assert.calledOnce(setTestEnvsStub);
           sinon.assert.calledOnce(setLocalStub);
-          sinon.assert.calledOnce(setLocalModeStub);
           sinon.assert.calledOnce(setLocalConfigFileStub);
           sinon.assert.calledOnce(setHeadedStub);
           sinon.assert.calledOnce(capabilityValidatorStub);

--- a/test/unit/bin/helpers/capabilityHelper.js
+++ b/test/unit/bin/helpers/capabilityHelper.js
@@ -1044,6 +1044,78 @@ describe("capabilityHelper.js", () => {
             });
         })
       });
+
+      context("Validation for local identifier", () => {
+        it("should throw error when local identifier is set to empty string", () => {
+          bsConfig.connection_settings = {};
+          bsConfig.connection_settings.local_identifier = "";
+
+          return capabilityHelper
+            .validate(bsConfig, {})
+            .then(function (data) {
+              chai.assert.fail("Promise error");
+            })
+            .catch((error) => {
+              chai.assert.equal(
+                error,
+                Constants.validationMessages.INVALID_LOCAL_IDENTIFIER
+              );
+            });
+        });
+      });
+
+      context("Validation for local mode", () => {
+        it("should throw error when local mode is set to empty string", () => {
+          bsConfig.connection_settings = {};
+          bsConfig.connection_settings.local_mode = "";
+
+          return capabilityHelper
+            .validate(bsConfig, {})
+            .then(function (data) {
+              chai.assert.fail("Promise error");
+            })
+            .catch((error) => {
+              chai.assert.equal(
+                error,
+                Constants.validationMessages.INVALID_LOCAL_MODE
+              );
+            });
+        });
+
+        it("should throw error when local mode is set to boolean value", () => {
+          bsConfig.connection_settings = {};
+          bsConfig.connection_settings.local_mode = true;
+
+          return capabilityHelper
+            .validate(bsConfig, {})
+            .then(function (data) {
+              chai.assert.fail("Promise error");
+            })
+            .catch((error) => {
+              chai.assert.equal(
+                error,
+                Constants.validationMessages.INVALID_LOCAL_MODE
+              );
+            });
+        });
+
+        it("should throw error when local mode is set to strings other then 'on-demand' / 'always-on'", () => {
+          bsConfig.connection_settings = {};
+          bsConfig.connection_settings.local_mode = "random-string";
+
+          return capabilityHelper
+            .validate(bsConfig, {})
+            .then(function (data) {
+              chai.assert.fail("Promise error");
+            })
+            .catch((error) => {
+              chai.assert.equal(
+                error,
+                Constants.validationMessages.INVALID_LOCAL_MODE
+              );
+            });
+        });
+      });
     });
   });
 });

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -1587,6 +1587,138 @@ describe('utils', () => {
     });
   })
 
+  describe('#invalidLocalMode', () => {
+    let bsConfig, args;
+    beforeEach(() => {
+      bsConfig = {
+        connection_settings: {}
+      }
+      args = {}
+    });
+
+    context('from bsConfig JSON', () => {
+      beforeEach(() => {
+        sinon.stub(utils,"searchForOption").returns(false);
+      });
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it('empty string is invalid local mode', () => {
+        bsConfig.connection_settings.local_mode = "";
+        expect(utils.invalidLocalMode(bsConfig, args)).to.eq(true);
+      });
+
+      it('any string other then "on-demand" / "alwasy-on" are invalid local mode', () => {
+        bsConfig.connection_settings.local_mode = "random-string";
+        expect(utils.invalidLocalMode(bsConfig, args)).to.eq(true);
+      });
+
+      it('boolean values are invalid local mode', () => {
+        bsConfig.connection_settings.local_mode = true;
+        expect(utils.invalidLocalMode(bsConfig, args)).to.eq(true);
+        bsConfig.connection_settings.local_mode = false;
+        expect(utils.invalidLocalMode(bsConfig, args)).to.eq(true);
+      });
+
+      it('"on-demand" is a valid local mode', () => {
+        bsConfig.connection_settings.local_mode = "on-demand";
+        expect(utils.invalidLocalMode(bsConfig, args)).to.eq(false);
+      });
+
+      it('"always-on" is a valid local mode', () => {
+        bsConfig.connection_settings.local_mode = "always-on";
+        expect(utils.invalidLocalMode(bsConfig, args)).to.eq(false);
+      });
+    });
+
+    context('from cli args', () => {
+      beforeEach(() => {
+        sinon.stub(utils,"searchForOption").returns(true);
+      });
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it('empty string is invalid local mode', () => {
+        args.localMode = "";
+        expect(utils.invalidLocalMode(bsConfig, args)).to.eq(true);
+      });
+
+      it('any string other then "on-demand" / "alwasy-on" are invalid local mode', () => {
+        args.localMode = "random-string";
+        expect(utils.invalidLocalMode(bsConfig, args)).to.eq(true);
+      });
+
+      it('boolean values are invalid local mode', () => {
+        args.localMode = true;
+        expect(utils.invalidLocalMode(bsConfig, args)).to.eq(true);
+        args.localMode = false;
+        expect(utils.invalidLocalMode(bsConfig, args)).to.eq(true);
+      });
+
+      it('"on-demand" is a valid local mode', () => {
+        args.localMode = "on-demand";
+        expect(utils.invalidLocalMode(bsConfig, args)).to.eq(false);
+      });
+
+      it('"always-on" is a valid local mode', () => {
+        args.localMode = "always-on";
+        expect(utils.invalidLocalMode(bsConfig, args)).to.eq(false);
+      });
+    });
+  });
+
+  describe('#invalidLocalIdentifier', () => {
+    let bsConfig, args;
+    beforeEach(() => {
+      bsConfig = {
+        connection_settings: {}
+      }
+      args = {}
+    });
+
+    context('from bsConfig JSON', () => {
+      beforeEach(() => {
+        sinon.stub(utils,"searchForOption").returns(false);
+      });
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it('empty string is invalid local identifier', () => {
+        bsConfig.connection_settings.local_identifier = "";
+        expect(utils.invalidLocalIdentifier(bsConfig, args)).to.eq(true);
+      });
+
+      it('non empty strings are valid local identifier', () => {
+        bsConfig.connection_settings.local_identifier = "local-id";
+        expect(utils.invalidLocalIdentifier(bsConfig, args)).to.eq(false);
+      });
+    });
+
+    context('from cli args', () => {
+      beforeEach(() => {
+        sinon.stub(utils,"searchForOption").returns(true);
+      });
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it('empty string is invalid local identifier', () => {
+        args.localIdentifier = "";
+        expect(utils.invalidLocalIdentifier(bsConfig, args)).to.eq(true);
+      });
+
+      it('non empty strings are valid local identifier', () => {
+        [true, false, 11111, "11111", "random-id"].forEach(id => {
+          args.localIdentifier = id;
+          expect(utils.invalidLocalIdentifier(bsConfig, args)).to.eq(false);
+        })
+      });
+    });
+  });
+
   describe('#deleteBaseUrlFromError', () => {
     it('Replace baseUrl in Local error string', () => {
       let error = constant.validationMessages.LOCAL_NOT_SET;


### PR DESCRIPTION
Adds validation around local id and mode.
- local Identifier: Handle empty string
- local mode: handle boolean and other string values other than (on-demand / always on)