### PR TITLE
text resizing based on the terminal column's width for sync logs

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -54,6 +54,9 @@ module.exports = function run(args) {
     // run test in headed mode
     utils.setHeaded(bsConfig, args);
 
+    // set the no-wrap
+    utils.setNoWrap(bsConfig, args);
+
     // Validate browserstack.json values and parallels specified via arguments
     return capabilityHelper.validate(bsConfig, args).then(function (cypressJson) {
 
@@ -119,7 +122,7 @@ module.exports = function run(args) {
             utils.sendUsageReport(bsConfig, args, err, Constants.messageTypes.ERROR, 'build_failed');
           });
         }).catch(function (err) {
-          // Zip Upload failed | Local Start failed 
+          // Zip Upload failed | Local Start failed
           logger.error(err);
           if(err === Constants.userMessages.LOCAL_START_FAILED){
             utils.sendUsageReport(bsConfig, args, `${err}\n${Constants.userMessages.LOCAL_START_FAILED}`, Constants.messageTypes.ERROR, 'local_start_failed');

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -104,7 +104,8 @@ const cliMessages = {
     LOCAL: "Accepted values: (true | false) - create a local testing connection to let you test staging and localhost websites, or sites behind proxies; learn more at browserstack.com/local-testing",
     LOCAL_MODE: 'Accepted values: ("always-on" | "on-demand") - if you choose to keep the binary "always-on", it will speed up your tests by keeping the Local connection warmed up in the background; otherwise, you can choose to have it spawn and killed for every build',
     LOCAL_IDENTIFIER: "Accepted values: String - assign an identifier to your Local process instance",
-    LOCAL_CONFIG_FILE: "Accepted values: String - path to local config-file to your Local process instance. Learn more at https://www.browserstack.com/local-testing/binary-params"
+    LOCAL_CONFIG_FILE: "Accepted values: String - path to local config-file to your Local process instance. Learn more at https://www.browserstack.com/local-testing/binary-params",
+    NO_WRAP: "Wrap the spec names in --sync mode in case of smaller terminal window size pass --no-wrap"
   },
   COMMON: {
     DISABLE_USAGE_REPORTING: "Disable usage reporting",

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -105,7 +105,7 @@ const cliMessages = {
     LOCAL_MODE: 'Accepted values: ("always-on" | "on-demand") - if you choose to keep the binary "always-on", it will speed up your tests by keeping the Local connection warmed up in the background; otherwise, you can choose to have it spawn and killed for every build',
     LOCAL_IDENTIFIER: "Accepted values: String - assign an identifier to your Local process instance",
     LOCAL_CONFIG_FILE: "Accepted values: String - path to local config-file to your Local process instance. Learn more at https://www.browserstack.com/local-testing/binary-params",
-    NO_WRAP: "Wrap the spec names in --sync mode in case of smaller terminal window size pass --no-wrap"
+    SYNC_NO_WRAP: "Wrap the spec names in --sync mode in case of smaller terminal window size pass --no-wrap"
   },
   COMMON: {
     DISABLE_USAGE_REPORTING: "Disable usage reporting",

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -13,7 +13,7 @@ let specSummary = {
   "specs": [],
   "duration": null
 }
-let terminalWidth = (process.stdout.columns) * 0.9;
+let terminalWidth = (process.stdout.columns);
 
 let  getOptions = (auth, build_id) => {
   return {
@@ -34,8 +34,8 @@ let getTableConfig = () => {
   return {
     border: getBorderConfig(),
     columns: {
-      1: {alignment: 'center', width: 1},
-      2: {alignment: 'left', width: Math.floor(terminalWidth * 0.8)}
+      1: {alignment: 'center', width: Math.ceil(terminalWidth * 0.01)},
+      2: {alignment: 'left', width: Math.floor(terminalWidth * 0.70)}
     },
     columnDefault: {
       width: Math.floor(terminalWidth * 0.2),

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -31,14 +31,15 @@ let  getOptions = (auth, build_id) => {
 }
 
 let getTableConfig = () => {
+  let terminalWidth = (process.stdout.columns)*0.9;
   return {
     border: getBorderConfig(),
     columns: {
       1: {alignment: 'center', width: 1},
-      2: {alignment: 'left', width: 100}
+      2: {alignment: 'left', width: Math.floor(terminalWidth*0.8)}
     },
     columnDefault: {
-      width: 30,
+      width: Math.floor(terminalWidth*0.2),
     },
     columnCount: 3,
   };

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -13,7 +13,7 @@ let specSummary = {
   "specs": [],
   "duration": null
 }
-let noWrap = (process.env.SYNC_NO_WRAP || false);
+let noWrap = (process.env.SYNC_NO_WRAP && (process.env.SYNC_NO_WRAP === 'true'));
 let terminalWidth = (process.stdout.columns) * 0.9;
 let lineSeparator = "\n" + "-".repeat(terminalWidth);
 // Do not show the separator based on terminal width if no-wrap provided.

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -35,7 +35,7 @@ let getTableConfig = () => {
     border: getBorderConfig(),
     columns: {
       1: {alignment: 'center', width: 1},
-      2: {alignment: 'left', width: Math.floor(terminalWidth*0.8)}
+      2: {alignment: 'left', width: Math.floor(terminalWidth * 0.8)}
     },
     columnDefault: {
       width: Math.floor(terminalWidth * 0.2),

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -15,9 +15,10 @@ let specSummary = {
 }
 let noWrap = (process.env.SYNC_NO_WRAP || false);
 let terminalWidth = (process.stdout.columns) * 0.9;
-let lineSeparator = "\n--------------------------------------------------------------------------------";
+let lineSeparator = "\n" + "-".repeat(terminalWidth);
+// Do not show the separator based on terminal width if no-wrap provided.
 if (noWrap) {
-  lineSeparator = "\n" + "-".repeat(terminalWidth);
+  lineSeparator = "\n--------------------------------------------------------------------------------";
 }
 
 let  getOptions = (auth, build_id) => {

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -13,13 +13,9 @@ let specSummary = {
   "specs": [],
   "duration": null
 }
-let noWrap = (process.env.SYNC_NO_WRAP && (process.env.SYNC_NO_WRAP === 'true'));
+let noWrap = false;
 let terminalWidth = (process.stdout.columns) * 0.9;
 let lineSeparator = "\n" + "-".repeat(terminalWidth);
-// Do not show the separator based on terminal width if no-wrap provided.
-if (noWrap) {
-  lineSeparator = "\n--------------------------------------------------------------------------------";
-}
 
 let  getOptions = (auth, build_id) => {
   return {
@@ -84,7 +80,16 @@ let getBorderConfig = () => {
   }
 }
 
+let setNoWrapParams = () => {
+  noWrap = (process.env.SYNC_NO_WRAP && (process.env.SYNC_NO_WRAP === 'true'));
+  // Do not show the separator based on terminal width if no-wrap provided.
+  if (noWrap) {
+    lineSeparator = "\n--------------------------------------------------------------------------------";
+  }
+};
+
 let printSpecsStatus = (bsConfig, buildDetails) => {
+  setNoWrapParams();
   return new Promise((resolve, reject) => {
     options = getOptions(bsConfig.auth, buildDetails.build_id)
     tableConfig = getTableConfig();

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -13,7 +13,7 @@ let specSummary = {
   "specs": [],
   "duration": null
 }
-
+let terminalWidth = (process.stdout.columns)*0.9;
 
 let  getOptions = (auth, build_id) => {
   return {
@@ -31,7 +31,6 @@ let  getOptions = (auth, build_id) => {
 }
 
 let getTableConfig = () => {
-  let terminalWidth = (process.stdout.columns)*0.9;
   return {
     border: getBorderConfig(),
     columns: {
@@ -82,7 +81,7 @@ let printSpecsStatus = (bsConfig, buildDetails) => {
         whileProcess(callback)
       },
       function(err, result) { // when loop ends
-        logger.info("\n--------------------------------------------------------------------------------")
+        logger.info(`\n${"-".repeat(terminalWidth)}`)
         specSummary.duration =  endTime - startTime
         resolve(specSummary)
       }
@@ -140,7 +139,7 @@ let showSpecsStatus = (data) => {
 
 let printInitialLog = () => {
   logger.info(`\n${Constants.syncCLI.LOGS.INIT_LOG}`)
-  logger.info("--------------------------------------------------------------------------------")
+  logger.info(`\n${"-".repeat(terminalWidth)}`)
   n = Constants.syncCLI.INITIAL_DELAY_MULTIPLIER
 }
 

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -13,7 +13,7 @@ let specSummary = {
   "specs": [],
   "duration": null
 }
-let terminalWidth = (process.stdout.columns)*0.9;
+let terminalWidth = (process.stdout.columns) * 0.9;
 
 let  getOptions = (auth, build_id) => {
   return {
@@ -38,7 +38,7 @@ let getTableConfig = () => {
       2: {alignment: 'left', width: Math.floor(terminalWidth*0.8)}
     },
     columnDefault: {
-      width: Math.floor(terminalWidth*0.2),
+      width: Math.floor(terminalWidth * 0.2),
     },
     columnCount: 3,
   };
@@ -81,7 +81,7 @@ let printSpecsStatus = (bsConfig, buildDetails) => {
         whileProcess(callback)
       },
       function(err, result) { // when loop ends
-        logger.info(`\n${"-".repeat(terminalWidth)}`)
+        logger.info("\n" + "-".repeat(terminalWidth))
         specSummary.duration =  endTime - startTime
         resolve(specSummary)
       }
@@ -139,7 +139,7 @@ let showSpecsStatus = (data) => {
 
 let printInitialLog = () => {
   logger.info(`\n${Constants.syncCLI.LOGS.INIT_LOG}`)
-  logger.info(`\n${"-".repeat(terminalWidth)}`)
+  logger.info("\n" + "-".repeat(terminalWidth))
   n = Constants.syncCLI.INITIAL_DELAY_MULTIPLIER
 }
 

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -13,8 +13,12 @@ let specSummary = {
   "specs": [],
   "duration": null
 }
-let noWrap = utils.searchForOption('--no-wrap')
+let noWrap = (process.env.SYNC_NO_WRAP || false);
 let terminalWidth = (process.stdout.columns) * 0.9;
+let lineSeparator = "\n--------------------------------------------------------------------------------";
+if (noWrap) {
+  lineSeparator = "\n" + "-".repeat(terminalWidth);
+}
 
 let  getOptions = (auth, build_id) => {
   return {
@@ -32,14 +36,25 @@ let  getOptions = (auth, build_id) => {
 }
 
 let getTableConfig = () => {
+  let centerWidth = Math.ceil(terminalWidth * 0.01),
+      leftWidth = Math.floor(terminalWidth * 0.75),
+      colWidth = Math.floor(terminalWidth * 0.2);
+
+  // Do not autosize on terminal's width if no-wrap provided
+  if (noWrap) {
+    centerWidth = 1;
+    leftWidth = 100;
+    colWidth = 30;
+  }
+
   return {
     border: getBorderConfig(),
     columns: {
-      1: {alignment: 'center', width: noWrap ? 1 : Math.ceil(terminalWidth * 0.01)},
-      2: {alignment: 'left', width: noWrap ? 100 : Math.floor(terminalWidth * 0.75)}
+      1: {alignment: 'center', width: centerWidth},
+      2: {alignment: 'left', width: leftWidth}
     },
     columnDefault: {
-      width: noWrap ? 30 : Math.floor(terminalWidth * 0.2),
+      width: colWidth,
     },
     columnCount: 3,
   };
@@ -82,7 +97,7 @@ let printSpecsStatus = (bsConfig, buildDetails) => {
         whileProcess(callback)
       },
       function(err, result) { // when loop ends
-        noWrap ? logger.info("\n--------------------------------------------------------------------------------") : logger.info("\n" + "-".repeat(terminalWidth))
+        logger.info(lineSeparator);
         specSummary.duration =  endTime - startTime
         resolve(specSummary)
       }
@@ -140,7 +155,7 @@ let showSpecsStatus = (data) => {
 
 let printInitialLog = () => {
   logger.info(`\n${Constants.syncCLI.LOGS.INIT_LOG}`)
-  noWrap ? logger.info("\n--------------------------------------------------------------------------------") : logger.info("\n" + "-".repeat(terminalWidth))
+  logger.info(lineSeparator);
   n = Constants.syncCLI.INITIAL_DELAY_MULTIPLIER
 }
 

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -34,8 +34,8 @@ let getTableConfig = () => {
   return {
     border: getBorderConfig(),
     columns: {
-      1: {alignment: 'center', width: 1},
-      2: {alignment: 'left', width: Math.floor(terminalWidth * 0.8)}
+      1: {alignment: 'center', width: Math.ceil(terminalWidth * 0.01)},
+      2: {alignment: 'left', width: Math.floor(terminalWidth * 0.75)}
     },
     columnDefault: {
       width: Math.floor(terminalWidth * 0.2),

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -13,7 +13,7 @@ let specSummary = {
   "specs": [],
   "duration": null
 }
-let terminalWidth = (process.stdout.columns);
+let terminalWidth = (process.stdout.columns) * 0.9;
 
 let  getOptions = (auth, build_id) => {
   return {
@@ -34,8 +34,8 @@ let getTableConfig = () => {
   return {
     border: getBorderConfig(),
     columns: {
-      1: {alignment: 'center', width: Math.ceil(terminalWidth * 0.01)},
-      2: {alignment: 'left', width: Math.floor(terminalWidth * 0.70)}
+      1: {alignment: 'center', width: 1},
+      2: {alignment: 'left', width: Math.floor(terminalWidth * 0.8)}
     },
     columnDefault: {
       width: Math.floor(terminalWidth * 0.2),

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -13,6 +13,7 @@ let specSummary = {
   "specs": [],
   "duration": null
 }
+let noWrap = utils.searchForOption('--no-wrap')
 let terminalWidth = (process.stdout.columns) * 0.9;
 
 let  getOptions = (auth, build_id) => {
@@ -34,11 +35,11 @@ let getTableConfig = () => {
   return {
     border: getBorderConfig(),
     columns: {
-      1: {alignment: 'center', width: Math.ceil(terminalWidth * 0.01)},
-      2: {alignment: 'left', width: Math.floor(terminalWidth * 0.75)}
+      1: {alignment: 'center', width: noWrap ? 1 : Math.ceil(terminalWidth * 0.01)},
+      2: {alignment: 'left', width: noWrap ? 100 : Math.floor(terminalWidth * 0.75)}
     },
     columnDefault: {
-      width: Math.floor(terminalWidth * 0.2),
+      width: noWrap ? 30 : Math.floor(terminalWidth * 0.2),
     },
     columnCount: 3,
   };
@@ -81,7 +82,7 @@ let printSpecsStatus = (bsConfig, buildDetails) => {
         whileProcess(callback)
       },
       function(err, result) { // when loop ends
-        logger.info("\n" + "-".repeat(terminalWidth))
+        noWrap ? logger.info("\n--------------------------------------------------------------------------------") : logger.info("\n" + "-".repeat(terminalWidth))
         specSummary.duration =  endTime - startTime
         resolve(specSummary)
       }
@@ -139,7 +140,7 @@ let showSpecsStatus = (data) => {
 
 let printInitialLog = () => {
   logger.info(`\n${Constants.syncCLI.LOGS.INIT_LOG}`)
-  logger.info("\n" + "-".repeat(terminalWidth))
+  noWrap ? logger.info("\n--------------------------------------------------------------------------------") : logger.info("\n" + "-".repeat(terminalWidth))
   n = Constants.syncCLI.INITIAL_DELAY_MULTIPLIER
 }
 

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -571,6 +571,14 @@ exports.setHeaded = (bsConfig, args) => {
   }
 };
 
+exports.setNoWrap = (_bsConfig, args) => {
+  if (args.noWrap === true) {
+    process.env.SYNC_NO_WRAP = true;
+  } else {
+    process.env.SYNC_NO_WRAP = false;
+  }
+}
+
 exports.getNumberOfSpecFiles = (bsConfig, args, cypressJson) => {
   let testFolderPath = cypressJson.integrationFolder || Constants.DEFAULT_CYPRESS_SPEC_PATH;
   let globSearchPattern = this.sanitizeSpecsPattern(bsConfig.run_settings.specs) || `${testFolderPath}/**/*.+(${Constants.specFileTypes.join("|")})`;

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -572,7 +572,7 @@ exports.setHeaded = (bsConfig, args) => {
 };
 
 exports.setNoWrap = (_bsConfig, args) => {
-  if (args.noWrap === true) {
+  if (args.noWrap === true || this.searchForOption('--no-wrap')) {
     process.env.SYNC_NO_WRAP = true;
   } else {
     process.env.SYNC_NO_WRAP = false;

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -223,7 +223,9 @@ var argv = yargs
           type: "string"
         },
         'no-wrap': {
-          describe: Constants.cliMessages.RUN.NO_WRAP
+          default: false,
+          describe: Constants.cliMessages.RUN.SYNC_NO_WRAP,
+          type: "boolean"
         }
       })
       .help('help')

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -221,6 +221,9 @@ var argv = yargs
         'local-config-file': {
           describe: Constants.cliMessages.RUN.LOCAL_CONFIG_FILE,
           type: "string"
+        },
+        'no-wrap': {
+          describe: Constants.cliMessages.RUN.NO_WRAP
         }
       })
       .help('help')

--- a/test/unit/bin/commands/runs.js
+++ b/test/unit/bin/commands/runs.js
@@ -101,6 +101,7 @@ describe("runs", () => {
       setLocalStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       setHeadedStub = sandbox.stub();
+      setNoWrapStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
       setDefaultsStub = sandbox.stub();
       setLocalModeStub = sandbox.stub();
@@ -133,6 +134,7 @@ describe("runs", () => {
           setLocal: setLocalStub,
           setLocalIdentifier: setLocalIdentifierStub,
           setHeaded: setHeadedStub,
+          setNoWrap: setNoWrapStub,
           deleteResults: deleteResultsStub,
           setDefaults: setDefaultsStub,
           setupLocalTesting: setupLocalTestingStub,
@@ -169,6 +171,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(setLocalModeStub);
           sinon.assert.calledOnce(setLocalConfigFileStub);
           sinon.assert.calledOnce(setHeadedStub);
+          sinon.assert.calledOnce(setNoWrapStub);
           sinon.assert.calledOnce(capabilityValidatorStub);
           sinon.assert.calledOnce(getErrorCodeFromMsgStub);
           sinon.assert.calledOnce(setLocalIdentifierStub);
@@ -211,6 +214,7 @@ describe("runs", () => {
       setupLocalTestingStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       setHeadedStub = sandbox.stub();
+      setNoWrapStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
       getNumberOfSpecFilesStub = sandbox.stub().returns([]);
       setDefaultsStub = sandbox.stub();
@@ -245,6 +249,7 @@ describe("runs", () => {
           setupLocalTesting: setupLocalTestingStub,
           setLocalIdentifier: setLocalIdentifierStub,
           setHeaded: setHeadedStub,
+          setNoWrap: setNoWrapStub,
           deleteResults: deleteResultsStub,
           setDefaults: setDefaultsStub,
           getNumberOfSpecFiles: getNumberOfSpecFilesStub,
@@ -284,6 +289,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(setLocalStub);
           sinon.assert.calledOnce(setLocalIdentifierStub);
           sinon.assert.calledOnce(setHeadedStub);
+          sinon.assert.calledOnce(setNoWrapStub);
           sinon.assert.calledOnce(validateBstackJsonStub);
           sinon.assert.calledOnce(capabilityValidatorStub);
           sinon.assert.calledOnce(archiverStub);
@@ -330,6 +336,7 @@ describe("runs", () => {
       setupLocalTestingStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       setHeadedStub = sandbox.stub();
+      setNoWrapStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
       getNumberOfSpecFilesStub = sandbox.stub().returns([]);
       setDefaultsStub = sandbox.stub();
@@ -364,6 +371,7 @@ describe("runs", () => {
           setupLocalTesting: setupLocalTestingStub,
           setLocalIdentifier: setLocalIdentifierStub,
           setHeaded: setHeadedStub,
+          setNoWrap: setNoWrapStub,
           deleteResults: deleteResultsStub,
           getNumberOfSpecFiles: getNumberOfSpecFilesStub,
           setDefaults: setDefaultsStub,
@@ -403,6 +411,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(setLocalStub);
           sinon.assert.calledOnce(setLocalIdentifierStub);
           sinon.assert.calledOnce(setHeadedStub);
+          sinon.assert.calledOnce(setNoWrapStub);
           sinon.assert.calledOnce(validateBstackJsonStub);
           sinon.assert.calledOnce(capabilityValidatorStub);
           sinon.assert.calledOnce(archiverStub);
@@ -453,6 +462,7 @@ describe("runs", () => {
       setupLocalTestingStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       setHeadedStub = sandbox.stub();
+      setNoWrapStub = sandbox.stub();
       deleteResultsStub = sandbox.stub();
       getNumberOfSpecFilesStub = sandbox.stub().returns([]);
       setDefaultsStub = sandbox.stub();
@@ -488,6 +498,7 @@ describe("runs", () => {
           setupLocalTesting: setupLocalTestingStub,
           setLocalIdentifier: setLocalIdentifierStub,
           setHeaded: setHeadedStub,
+          setNoWrap: setNoWrapStub,
           deleteResults: deleteResultsStub,
           getNumberOfSpecFiles: getNumberOfSpecFilesStub,
           setDefaults: setDefaultsStub,
@@ -538,6 +549,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(setLocalStub);
           sinon.assert.calledOnce(setLocalIdentifierStub);
           sinon.assert.calledOnce(setHeadedStub);
+          sinon.assert.calledOnce(setNoWrapStub);
           sinon.assert.calledOnce(archiverStub);
           sinon.assert.calledOnce(setUsageReportingFlagStub);
           sinon.assert.calledOnce(zipUploadStub);
@@ -593,6 +605,7 @@ describe("runs", () => {
       setupLocalTestingStub = sandbox.stub();
       setLocalIdentifierStub = sandbox.stub();
       setHeadedStub = sandbox.stub();
+      setNoWrapStub = sandbox.stub();
       getNumberOfSpecFilesStub = sandbox.stub().returns([]);
       setLocalConfigFileStub = sandbox.stub();
     });
@@ -626,6 +639,7 @@ describe("runs", () => {
           setupLocalTesting: setupLocalTestingStub,
           setLocalIdentifier: setLocalIdentifierStub,
           setHeaded: setHeadedStub,
+          setNoWrap: setNoWrapStub,
           exportResults: exportResultsStub,
           deleteResults: deleteResultsStub,
           setDefaults: setDefaultsStub,
@@ -679,6 +693,7 @@ describe("runs", () => {
           sinon.assert.calledOnce(setupLocalTestingStub);
           sinon.assert.calledOnce(setLocalIdentifierStub);
           sinon.assert.calledOnce(setHeadedStub);
+          sinon.assert.calledOnce(setNoWrapStub);
           sinon.assert.calledOnce(archiverStub);
           sinon.assert.calledOnce(setUsageReportingFlagStub);
           sinon.assert.calledOnce(zipUploadStub);

--- a/test/unit/bin/helpers/sync/syncSpecsLogs.js
+++ b/test/unit/bin/helpers/sync/syncSpecsLogs.js
@@ -92,11 +92,11 @@ describe("syncSpecsLogs", () => {
       syncSpecsLogs.__set__('getBorderConfig', getBorderConfigStub);
 
       let options = getTableConfig();
-      expect(options.columnDefault.width).to.equal(30);
+      expect(options.columnDefault.width).to.equal(Math.floor(((process.stdout.columns)*0.9)*0.2));
       expect(options.columns[1].alignment).to.equal('center');
       expect(options.columns[2].alignment).to.equal('left');
       expect(options.columns[1].width).to.equal(1);
-      expect(options.columns[2].width).to.equal(100);
+      expect(options.columns[2].width).to.equal(Math.floor(((process.stdout.columns)*0.9)*0.8));
       expect(options.columnCount).to.equal(3);
       expect(getBorderConfigStub.calledOnce).to.be.true;
     });

--- a/test/unit/bin/helpers/sync/syncSpecsLogs.js
+++ b/test/unit/bin/helpers/sync/syncSpecsLogs.js
@@ -92,11 +92,11 @@ describe("syncSpecsLogs", () => {
       syncSpecsLogs.__set__('getBorderConfig', getBorderConfigStub);
 
       let options = getTableConfig();
-      expect(options.columnDefault.width).to.equal(Math.floor(((process.stdout.columns)*0.9)*0.2));
+      expect(options.columnDefault.width).to.equal(Math.floor(((process.stdout.columns) * 0.9) * 0.2));
       expect(options.columns[1].alignment).to.equal('center');
       expect(options.columns[2].alignment).to.equal('left');
       expect(options.columns[1].width).to.equal(1);
-      expect(options.columns[2].width).to.equal(Math.floor(((process.stdout.columns)*0.9)*0.8));
+      expect(options.columns[2].width).to.equal(Math.floor(((process.stdout.columns) * 0.9) * 0.8));
       expect(options.columnCount).to.equal(3);
       expect(getBorderConfigStub.calledOnce).to.be.true;
     });

--- a/test/unit/bin/helpers/sync/syncSpecsLogs.js
+++ b/test/unit/bin/helpers/sync/syncSpecsLogs.js
@@ -95,8 +95,8 @@ describe("syncSpecsLogs", () => {
       expect(options.columnDefault.width).to.equal(Math.floor(((process.stdout.columns) * 0.9) * 0.2));
       expect(options.columns[1].alignment).to.equal('center');
       expect(options.columns[2].alignment).to.equal('left');
-      expect(options.columns[1].width).to.equal(1);
-      expect(options.columns[2].width).to.equal(Math.floor(((process.stdout.columns) * 0.9) * 0.8));
+      expect(options.columns[1].width).to.equal(Math.ceil(((process.stdout.columns) * 0.9) * 0.01));
+      expect(options.columns[2].width).to.equal(Math.floor(((process.stdout.columns) * 0.9) * 0.75));
       expect(options.columnCount).to.equal(3);
       expect(getBorderConfigStub.calledOnce).to.be.true;
     });

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -600,6 +600,44 @@ describe('utils', () => {
     });
   });
 
+  describe('setNoWrap', () => {
+    it('sets the no-wrap to process.env.SYNC_NO_WRAP to true', () => {
+      let args = {
+        noWrap: true
+      };
+      let bsConfig = {
+        run_settings: {}
+      };
+
+      utils.setNoWrap(bsConfig, args);
+      expect(process.env.SYNC_NO_WRAP).to.be.eq('true');
+    });
+
+    it('false to not set the no-wrap to process.env.SYNC_NO_WRAP to true', () => {
+      let args = {
+        noWrap: false
+      };
+      let bsConfig = {
+        run_settings: {}
+      };
+
+      utils.setNoWrap(bsConfig, args);
+      expect(process.env.SYNC_NO_WRAP).to.be.eq('false');
+    });
+
+    it('string to not set the no-wrap to process.env.SYNC_NO_WRAP to true', () => {
+      let args = {
+        noWrap: "true"
+      };
+      let bsConfig = {
+        run_settings: {}
+      };
+
+      utils.setNoWrap(bsConfig, args);
+      expect(process.env.SYNC_NO_WRAP).to.be.eq('false');
+    });
+  });
+
   describe('exportResults', () => {
     it('should export results to log/build_results.txt', () => {
       sinon.stub(fs, 'writeFileSync').returns(true);


### PR DESCRIPTION
We will be widening or shorting the width of the column which shows the sync result logs for individual specs based on the current terminal's column width.

This PR adds the dynamically adjusting the specs listing column width based on the terminal/process' col size. Provides an option `--no-wrap` to disable the feature in case the user does not want the column to be resized.
