### PR TITLE
Support for env variables using different ways

### DIFF
--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -93,32 +93,10 @@ const caps = (bsConfig, zip) => {
     obj.projectNotifyURL = null;
 
     if (bsConfig.run_settings) {
-      obj.project = bsConfig.run_settings.project || bsConfig.run_settings.project_name;
-      obj.customBuildName = bsConfig.run_settings.build_name || bsConfig.run_settings.customBuildName;
-      obj.callbackURL = bsConfig.run_settings.callback_url;
-      obj.projectNotifyURL = bsConfig.run_settings.project_notify_URL;
-      obj.parallels = bsConfig.run_settings.parallels;
-
-      if (!Utils.isUndefined(bsConfig.run_settings.cypress_config_filename)) {
-        obj.cypress_config_filename = bsConfig.run_settings.cypress_config_filename;
-      }
-
-      if (!Utils.isUndefined(bsConfig.run_settings.specs)){
-        obj.specs = bsConfig.run_settings.specs;
-      }
-
-      if (!Utils.isUndefined(bsConfig.run_settings.env)){
-        obj.env = bsConfig.run_settings.env;
-      }
-      if (!Utils.isUndefined(bsConfig.run_settings.cypress_version)){
-        obj.cypress_version = bsConfig.run_settings.cypress_version;
-      }
-
-      if (!Utils.isUndefined(bsConfig.run_settings.headless) && String(bsConfig.run_settings.headless) === "false"){
-        obj.headless = bsConfig.run_settings.headless;
-      } else {
+      if (!(!Utils.isUndefined(bsConfig.run_settings.headless) && String(bsConfig.run_settings.headless) === "false")) {
         logger.info(`Running your tests in headless mode. Use --headed arg to run in headful mode.`);
       }
+      obj.run_settings = bsConfig.run_settings;
     }
 
     if(obj.parallels === Constants.cliMessages.RUN.DEFAULT_PARALLEL_MESSAGE) obj.parallels = undefined

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -129,7 +129,7 @@ const messageTypes = {
   NULL: null
 }
 
-const allowedFileTypes = ['js', 'json', 'txt', 'ts', 'feature', 'features', 'pdf', 'jpg', 'jpeg', 'png', 'zip', 'npmrc', 'xml', 'doc', 'docx', 'ppt', 'pptx', 'xls', 'xlsx', 'jsx', 'coffee', 'cjsx', 'csv', 'tsv', 'yml', 'yaml'];
+const allowedFileTypes = ['js', 'json', 'txt', 'ts', 'feature', 'features', 'pdf', 'jpg', 'jpeg', 'png', 'zip', 'npmrc', 'xml', 'doc', 'docx', 'ppt', 'pptx', 'xls', 'xlsx', 'jsx', 'coffee', 'cjsx', 'csv', 'tsv', 'yml', 'yaml', 'env'];
 
 const filesToIgnoreWhileUploading = [
   '**/node_modules/**',

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -277,31 +277,31 @@ exports.setTestEnvs = (bsConfig, args) => {
   // set env vars which start with CYPRESS_ and cypress_
   let pattern = /^cypress_/i;
   let matchingKeys = this.getKeysMatchingPattern(process.env, pattern);
-  if (matchingKeys) {
+  if (matchingKeys && matchingKeys.length) {
     let envKeys = [];
     matchingKeys.forEach((envVar) => {
-      envKeys.push(`${envVar}=${process.env.envVar}`);
+      envKeys.push(`${envVar}=${process.env[envVar]}`);
     });
 
     if (bsConfig.run_settings.env !== null) {
       bsConfig.run_settings.env = `${bsConfig.run_settings.env},${envKeys.join(',')}`;
     } else {
-      bsConfig.run_settings.env = matchingKeys.join(',');
+      bsConfig.run_settings.env = envKeys.join(',');
     }
   }
 
   // set env vars which are defined in system_env_vars key
-  if(!this.undefined(bsConfig.run_settings.system_env_vars)) {
+  if(!this.isUndefined(bsConfig.run_settings.system_env_vars) && Array.isArray(bsConfig.run_settings.system_env_vars) && bsConfig.run_settings.system_env_vars.length) {
     let system_env_vars = bsConfig.run_settings.system_env_vars;
     let envKeys = [];
     system_env_vars.forEach((envVar) => {
-      envKeys.push(`${envVar}=${process.env.envVar}`);
+      envKeys.push(`${envVar}=${process.env[envVar]}`);
     });
 
     if (bsConfig.run_settings.env !== null) {
-      bsConfig.run_settings.env = `${bsConfig.run_settings.env},${system_env_vars.join(',')}`;
+      bsConfig.run_settings.env = `${bsConfig.run_settings.env},${envKeys.join(',')}`;
     } else {
-      bsConfig.run_settings.env = system_env_vars.join(',');
+      bsConfig.run_settings.env = envKeys.join(',');
     }
   }
 }

--- a/bin/templates/configTemplate.js
+++ b/bin/templates/configTemplate.js
@@ -61,7 +61,6 @@ module.exports = function () {
       },
       "package_config_options": {
       },
-      "system_env_vars": [],
       "headless": true
     },
     "connection_settings": {

--- a/bin/templates/configTemplate.js
+++ b/bin/templates/configTemplate.js
@@ -61,6 +61,7 @@ module.exports = function () {
       },
       "package_config_options": {
       },
+      "system_env_vars": [],
       "headless": true
     },
     "connection_settings": {


### PR DESCRIPTION
### User facing change log:
* Add support for uploading `*.env` files
* Add support for reading system environment vars using `system_env_vars`
* Add support for reading system variables given as `CYPRESS_*` or `cypress_*` - https://docs.cypress.io/guides/guides/environment-variables#Option-3-CYPRESS_

## Other changes:
* Move addition of capabilities without command line args to backend