### PR TITLE
Fix an error that happens when user sends cypress version in integer

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -116,7 +116,7 @@ module.exports = function run(args) {
               }
 
               if (bsConfig.run_settings.cypress_version && bsConfig.run_settings.cypress_version !== data.cypress_version) {
-                if (bsConfig.run_settings.cypress_version.match(Constants.LATEST_VERSION_SYNTAX_REGEX)) {
+                if (bsConfig.run_settings.cypress_version.toString().match(Constants.LATEST_VERSION_SYNTAX_REGEX)) {
                   let versionMessage = utils.latestSyntaxToActualVersionMessage(bsConfig.run_settings.cypress_version, data.cypress_version);
                   logger.info(versionMessage);
                 } else {


### PR DESCRIPTION
Currently, if the user passes the cypress major version in integer then an error is shown as we run a string function on that value. This PR fixes that issue.