### PR TITLE
Fix: Handle dynamic width calculation for CI/CD tests running with --sync

### DIFF
--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -5,7 +5,8 @@ const syncCLI = {
   LOGS: {
     INIT_LOG: "All tests:"
   },
-  INITIAL_DELAY_MULTIPLIER: 10
+  INITIAL_DELAY_MULTIPLIER: 10,
+  DEFAULT_LINE_SEP: "\n--------------------------------------------------------------------------------",
 };
 
 const userMessages = {

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -15,7 +15,8 @@ let specSummary = {
 }
 let noWrap = false;
 let terminalWidth = (process.stdout.columns) * 0.9;
-let lineSeparator = "\n" + "-".repeat(terminalWidth);
+let lineSeparator = Constants.syncCLI.DEFAULT_LINE_SEP;
+if (!utils.isUndefined(terminalWidth)) lineSeparator = "\n" + "-".repeat(terminalWidth);
 
 let  getOptions = (auth, build_id) => {
   return {
@@ -38,7 +39,7 @@ let getTableConfig = () => {
       colWidth = Math.floor(terminalWidth * 0.2);
 
   // Do not autosize on terminal's width if no-wrap provided
-  if (noWrap) {
+  if (noWrap || utils.isUndefined(terminalWidth)) {
     centerWidth = 1;
     leftWidth = 100;
     colWidth = 30;
@@ -84,7 +85,7 @@ let setNoWrapParams = () => {
   noWrap = (process.env.SYNC_NO_WRAP && (process.env.SYNC_NO_WRAP === 'true'));
   // Do not show the separator based on terminal width if no-wrap provided.
   if (noWrap) {
-    lineSeparator = "\n--------------------------------------------------------------------------------";
+    lineSeparator = Constants.syncCLI.DEFAULT_LINE_SEP;
   }
 };
 

--- a/bin/helpers/sync/syncSpecsLogs.js
+++ b/bin/helpers/sync/syncSpecsLogs.js
@@ -16,7 +16,7 @@ let specSummary = {
 let noWrap = false;
 let terminalWidth = (process.stdout.columns) * 0.9;
 let lineSeparator = Constants.syncCLI.DEFAULT_LINE_SEP;
-if (!utils.isUndefined(terminalWidth)) lineSeparator = "\n" + "-".repeat(terminalWidth);
+if (!isNaN(terminalWidth)) lineSeparator = "\n" + "-".repeat(terminalWidth);
 
 let  getOptions = (auth, build_id) => {
   return {
@@ -33,13 +33,13 @@ let  getOptions = (auth, build_id) => {
   };
 }
 
-let getTableConfig = () => {
-  let centerWidth = Math.ceil(terminalWidth * 0.01),
-      leftWidth = Math.floor(terminalWidth * 0.75),
-      colWidth = Math.floor(terminalWidth * 0.2);
+let getTableConfig = (termWidth) => {
+  let centerWidth = Math.ceil(termWidth * 0.01),
+      leftWidth = Math.floor(termWidth * 0.75),
+      colWidth = Math.floor(termWidth * 0.2);
 
   // Do not autosize on terminal's width if no-wrap provided
-  if (noWrap || utils.isUndefined(terminalWidth)) {
+  if (noWrap || isNaN(termWidth)) {
     centerWidth = 1;
     leftWidth = 100;
     colWidth = 30;
@@ -93,7 +93,7 @@ let printSpecsStatus = (bsConfig, buildDetails) => {
   setNoWrapParams();
   return new Promise((resolve, reject) => {
     options = getOptions(bsConfig.auth, buildDetails.build_id)
-    tableConfig = getTableConfig();
+    tableConfig = getTableConfig(terminalWidth);
     stream = tableStream(tableConfig);
 
     async.whilst(

--- a/test/unit/bin/helpers/sync/syncSpecsLogs.js
+++ b/test/unit/bin/helpers/sync/syncSpecsLogs.js
@@ -94,12 +94,26 @@ describe("syncSpecsLogs", () => {
       var getBorderConfigStub = sandbox.stub();
       syncSpecsLogs.__set__('getBorderConfig', getBorderConfigStub);
 
-      let options = getTableConfig();
+      let options = getTableConfig((process.stdout.columns) * 0.9);
       expect(options.columnDefault.width).to.equal(Math.floor(((process.stdout.columns) * 0.9) * 0.2));
       expect(options.columns[1].alignment).to.equal('center');
       expect(options.columns[2].alignment).to.equal('left');
       expect(options.columns[1].width).to.equal(Math.ceil(((process.stdout.columns) * 0.9) * 0.01));
       expect(options.columns[2].width).to.equal(Math.floor(((process.stdout.columns) * 0.9) * 0.75));
+      expect(options.columnCount).to.equal(3);
+      expect(getBorderConfigStub.calledOnce).to.be.true;
+    });
+
+    it('should return proper table config option for spec table if process.stdout.columns is not defined', () => {
+      var getBorderConfigStub = sandbox.stub();
+      syncSpecsLogs.__set__('getBorderConfig', getBorderConfigStub);
+
+      let options = getTableConfig(NaN);
+      expect(options.columnDefault.width).to.equal(30);
+      expect(options.columns[1].alignment).to.equal('center');
+      expect(options.columns[2].alignment).to.equal('left');
+      expect(options.columns[1].width).to.equal(1);
+      expect(options.columns[2].width).to.equal(100);
       expect(options.columnCount).to.equal(3);
       expect(getBorderConfigStub.calledOnce).to.be.true;
     });


### PR DESCRIPTION
Fix for: https://github.com/browserstack/browserstack-cypress-cli/issues/162