### PR TITLE
Fix sticky npm console message

### DIFF
--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -26,6 +26,7 @@ const userMessages = {
   MD5_CHECK_FAILED: "There was some issue while checking if zip is already uploaded.",
   ZIP_DELETE_FAILED: "Could not delete tests.zip successfully.",
   ZIP_DELETED: "Deleted tests.zip successfully.",
+  NPM_INSTALL_AND_UPLOAD: "Installing required dependencies and building the package to upload to BrowserStack",
   NPM_DELETE_FAILED: "Could not delete the dependency packages.",
   NPM_DELETED: "Deleted dependency packages successfully.",
   API_DEPRECATED: "This version of API is deprecated, please use latest version of API.",

--- a/bin/helpers/packageInstaller.js
+++ b/bin/helpers/packageInstaller.js
@@ -1,8 +1,6 @@
 'use strict';
-const npm = require('npm'),
-  archiver = require("archiver"),
+  const archiver = require("archiver"),
   path = require('path'),
-  os = require('os'),
   fs = require('fs-extra'),
   fileHelpers = require('./fileHelpers'),
   logger = require("./logger").winstonLogger,
@@ -109,7 +107,7 @@ const packageWrapper = (bsConfig, packageDir, packageFile, md5data, instrumentBl
     if (md5data.packageUrlPresent || !utils.isTrueString(bsConfig.run_settings.cache_dependencies)) {
       return resolve(obj);
     }
-    logger.info(`Installing required dependencies and building the package to upload to BrowserStack`);
+    logger.info(Constants.userMessages.NPM_INSTALL_AND_UPLOAD);
     instrumentBlocks.markBlockStart("packageInstaller.folderSetup");
     return setupPackageFolder(bsConfig.run_settings, packageDir).then((_result) => {
       process.env.CYPRESS_INSTALL_BINARY = 0

--- a/bin/helpers/packageInstaller.js
+++ b/bin/helpers/packageInstaller.js
@@ -52,20 +52,20 @@ const setupPackageFolder = (runSettings, directoryPath) => {
 
 const packageInstall = (packageDir) => {
   return new Promise(function (resolve, reject) {
-    nodeProcess = spawn('npm', ['install'], {cwd: packageDir});
     const nodeProcessCloseCallback = (code) => {
       if(code == 0) {
-        resolve('Packages were installed');
+        resolve('Packages were installed successfully.');
       } else {
-        reject('Packages were not installed');
+        reject('Packages were not installed successfully.');
       }
     };
     const nodeProcessErrorCallback = (error) => {
       logger.error(`Some error occurred while installing packages: ${error}`);
-      reject('Packages were not installed');
+      reject(`Packages were not installed successfully.`);
     };
-    nodeProcess.on('error', nodeProcessErrorCallback);
+    nodeProcess = spawn('npm', ['install'], {cwd: packageDir});
     nodeProcess.on('close', nodeProcessCloseCallback);
+    nodeProcess.on('error', nodeProcessErrorCallback);
   });
 };
 

--- a/bin/helpers/packageInstaller.js
+++ b/bin/helpers/packageInstaller.js
@@ -53,17 +53,19 @@ const setupPackageFolder = (runSettings, directoryPath) => {
 const packageInstall = (packageDir) => {
   return new Promise(function (resolve, reject) {
     nodeProcess = spawn('npm', ['install'], {cwd: packageDir});
-    nodeProcess.on('close', (code) => {
+    const nodeProcessCloseCallback = (code) => {
       if(code == 0) {
         resolve('Packages were installed');
       } else {
         reject('Packages were not installed');
       }
-    });
-    nodeProcess.on('error', (error) => {
+    };
+    const nodeProcessErrorCallback = (error) => {
       logger.error(`Some error occurred while installing packages: ${error}`);
       reject('Packages were not installed');
-    });
+    };
+    nodeProcess.on('error', nodeProcessErrorCallback);
+    nodeProcess.on('close', nodeProcessCloseCallback);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "uuid": "^8.3.2",
     "winston": "^2.3.1",
     "yargs": "^14.2.3",
-    "npm": "^6.14.15",
     "axios": "^0.21.1",
     "unzipper": "^0.10.11",
     "update-notifier": "^5.1.0"


### PR DESCRIPTION
This PR aims to fix the sticky console message that was introduced with v1.11.0 release during the npm dependencies install phase. It replaces the usage of the `npm` library with spawn child_process that runs the npm command.