### PR TITLE
Hardcode version of winston in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "unzipper": "^0.10.11",
     "update-notifier": "^5.1.0",
     "uuid": "^8.3.2",
-    "winston": "^2.3.1",
+    "winston": "2.4.4",
     "yargs": "^14.2.3"
   },
   "repository": {


### PR DESCRIPTION
Hardcoding the version of Winston to 2.4.4 which installs `colors` as a dependency. Doing this because latest version of colors is causing issues so to restrict users to install that unknowingly we are hardcoding Winston version which installs `colors@1.0.3` which works fine.

This PR is just for safety measures.