### PR TITLE
Fix "Error: spawn npm ENOENT" on windows

### DIFF
--- a/bin/helpers/packageInstaller.js
+++ b/bin/helpers/packageInstaller.js
@@ -63,7 +63,7 @@ const packageInstall = (packageDir) => {
       logger.error(`Some error occurred while installing packages: ${error}`);
       reject(`Packages were not installed successfully.`);
     };
-    nodeProcess = spawn('npm', ['install'], {cwd: packageDir});
+    nodeProcess = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install'], {cwd: packageDir});
     nodeProcess.on('close', nodeProcessCloseCallback);
     nodeProcess.on('error', nodeProcessErrorCallback);
   });


### PR DESCRIPTION
I was running this lib on windows with a few npm_dependencies and i got this spawn npm error.
![asd](https://user-images.githubusercontent.com/17620914/149764376-8c7e2fc5-9f85-4e1e-8bc4-5f97ab5c784d.png)

Fixed with the solution posted on SO: https://stackoverflow.com/a/43285131/11882999