### PR TITLE
Fix update notification issue

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -328,12 +328,16 @@ module.exports = function run(args, rawArgs) {
       pkg,
       updateCheckInterval: 1000 * 60 * 60 * 24 * 7,
     });
-    
+
+    // Checks for update on first run. 
+    // Set lastUpdateCheck to 0 to spawn the check update process as notifier sets this to Date.now() for preventing 
+    // the check untill one interval period. It runs once.
     if (!notifier.disabled && Date.now() - notifier.config.get('lastUpdateCheck') < 50) {
       notifier.config.set('lastUpdateCheck', 0);
       notifier.check();
     }
 
+    // Set the config update as notifier clears this after reading.
     if (notifier.update && notifier.update.current !== notifier.update.latest) {
       notifier.config.set('update', notifier.update);
       notifier.notify({isGlobal: true});

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -324,9 +324,14 @@ module.exports = function run(args, rawArgs) {
     utils.sendUsageReport(bsJsonData, args, err.message, Constants.messageTypes.ERROR, utils.getErrorCodeFromErr(err), null, rawArgs);
     process.exitCode = Constants.ERROR_EXIT_CODE;
   }).finally(function(){
-    updateNotifier({
+    const notifier = updateNotifier({
       pkg,
       updateCheckInterval: 1000 * 60 * 60 * 24 * 7,
-    }).notify({isGlobal: true});
+    });
+
+    if (notifier.update && notifier.update.current !== notifier.update.latest) {
+      notifier.config.set('update', notifier.update);
+      notifier.notify({isGlobal: true});
+    }
   });
 }

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -328,6 +328,11 @@ module.exports = function run(args, rawArgs) {
       pkg,
       updateCheckInterval: 1000 * 60 * 60 * 24 * 7,
     });
+    
+    if (!notifier.disabled && Date.now() - notifier.config.get('lastUpdateCheck') < 50) {
+      notifier.config.set('lastUpdateCheck', 0);
+      notifier.check();
+    }
 
     if (notifier.update && notifier.update.current !== notifier.update.latest) {
       notifier.config.set('update', notifier.update);


### PR DESCRIPTION
`update-notifier` package is clearing it's update config after one time read. Setting this config again on update availability. 