### PR TITLE
Ignore tests.zip from uploads when home_directory is set

### DIFF
--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -319,6 +319,7 @@ const filesToIgnoreWhileUploading = [
   "package.json",
   "browserstack-package.json",
   "tests.zip",
+  "**/tests.zip",
   "cypress.json",
   "cypress.config.js",
   "cypress.config.ts",


### PR DESCRIPTION
Adds `**/tests.zip` to the list of patterns ignored for uploading. 

This avoids recursion creating `tests.zip` when `home_directory` is defined.

Closes #440 