### PR TITLE
Change defaults w.r.t build artifacts

### DIFF
--- a/bin/testObservability/helper/helper.js
+++ b/bin/testObservability/helper/helper.js
@@ -753,7 +753,6 @@ exports.setTestObservabilityFlags = (bsConfig) => {
     exports.debug(`EXCEPTION while parsing testObservability capability with error ${e}`, true, e);
   }
   
-
   /* browserstackAutomation */
   let isBrowserstackInfra = true;
   try {
@@ -765,6 +764,7 @@ exports.setTestObservabilityFlags = (bsConfig) => {
     exports.debug(`EXCEPTION while parsing browserstackAutomation capability with error ${e}`, true, e);
   }
   
+  if(isTestObservabilitySession) logger.warn("testObservability is set to true. Other test reporters you are using will be automatically disabled. Learn more at browserstack.com/docs/test-observability/overview/what-is-test-observability");
 
   process.env.BROWSERSTACK_TEST_OBSERVABILITY = isTestObservabilitySession;
   process.env.BROWSERSTACK_AUTOMATION = isBrowserstackInfra;

--- a/bin/testObservability/helper/helper.js
+++ b/bin/testObservability/helper/helper.js
@@ -741,6 +741,9 @@ exports.setTestObservabilityFlags = (bsConfig) => {
   /* testObservability */
   let isTestObservabilitySession = false;
   try {
+    /* set default again but under try catch in case of wrong config */
+    isTestObservabilitySession = utils.nonEmptyArray(bsConfig.run_settings.downloads) ? false : true;
+
     if(!utils.isUndefined(bsConfig["testObservability"])) isTestObservabilitySession = ( bsConfig["testObservability"] == true || bsConfig["testObservability"] == 1 );
     if(!utils.isUndefined(process.env.BROWSERSTACK_TEST_OBSERVABILITY)) isTestObservabilitySession = ( process.env.BROWSERSTACK_TEST_OBSERVABILITY == "true" || process.env.BROWSERSTACK_TEST_OBSERVABILITY == "1" );
     if(process.argv.includes('--disable-test-observability')) isTestObservabilitySession = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
 - testObservability will be enabled by default if a user does not specify a valid argument for the downloads key in browserstack.json.
 - Version bump for the previous release i.e 1.24.1