### PR TITLE
OB-2080 Remove cypress event listeners temporarily

### DIFF
--- a/bin/testObservability/helper/helper.js
+++ b/bin/testObservability/helper/helper.js
@@ -583,7 +583,7 @@ exports.launchTestSession = async (user_config, bsConfigPath) => {
       exports.debug('Build creation successfull!');
       process.env.BS_TESTOPS_BUILD_COMPLETED = true;
       setEnvironmentVariablesForRemoteReporter(response.data.jwt, response.data.build_hashed_id, response.data.allow_screenshots, data.observability_version.sdkVersion);
-      setEventListeners();
+      // setEventListeners();
       if(this.isBrowserstackInfra()) setBrowserstackCypressCliDependency(user_config);
     } catch(error) {
       if(!error.errorType) {


### PR DESCRIPTION
Removing Cypress Event Listeners which are breaking tests running Cypress >= v12.15.x.