### PR TITLE
Avoid throwing exit error code if we get 404 for build artifacts

### DIFF
--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -95,6 +95,8 @@ const userMessages = {
     "You might not see all your results on the dashboard because of high spec count, please consider reducing the number of spec files in this folder.",
   DOWNLOAD_BUILD_ARTIFACTS_FAILED:
     "Downloading build artifacts for the build <build-id> failed for <machine-count> machines.",
+  DOWNLOAD_BUILD_ARTIFACTS_NOT_FOUND:
+    "Build Artifacts for the session <session-id> was either not generated or not uploaded.",
   ASYNC_DOWNLOADS:
     "Test artifacts as specified under 'downloads' can be downloaded after the build has completed its run, using 'browserstack-cypress generate-downloads <build-id>'",
   DOWNLOAD_BUILD_ARTIFACTS_SUCCESS:

--- a/bin/helpers/constants.js
+++ b/bin/helpers/constants.js
@@ -94,9 +94,9 @@ const userMessages = {
   SPEC_LIMIT_WARNING:
     "You might not see all your results on the dashboard because of high spec count, please consider reducing the number of spec files in this folder.",
   DOWNLOAD_BUILD_ARTIFACTS_FAILED:
-    "Downloading build artifacts for the build <build-id> failed for <machine-count> machines.",
+    "Downloading build artifact(s) for the build <build-id> failed for <machine-count> machines.",
   DOWNLOAD_BUILD_ARTIFACTS_NOT_FOUND:
-    "Build Artifacts for the session <session-id> was either not generated or not uploaded.",
+    "Build artifact(s) for the session <session-id> was either not generated or not uploaded.",
   ASYNC_DOWNLOADS:
     "Test artifacts as specified under 'downloads' can be downloaded after the build has completed its run, using 'browserstack-cypress generate-downloads <build-id>'",
   DOWNLOAD_BUILD_ARTIFACTS_SUCCESS:

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -1314,25 +1314,29 @@ exports.readBsConfigJSON = (bsConfigPath) => {
 }
 
 exports.getCypressConfigFile = (bsConfig) => {
-  let cypressConfigFile = undefined;
-  if (bsConfig.run_settings.cypressTestSuiteType === Constants.CYPRESS_V10_AND_ABOVE_TYPE) {
-    if (bsConfig.run_settings.cypress_config_filename.endsWith("cypress.config.js")) {
-      if (bsConfig.run_settings.cypress_config_file && bsConfig.run_settings.cypress_config_filename !== 'false') {
-        cypressConfigFile = require(path.resolve(bsConfig.run_settings.cypressConfigFilePath));
-      } else if (bsConfig.run_settings.cypressProjectDir) {
-        cypressConfigFile = require(path.join(bsConfig.run_settings.cypressProjectDir, bsConfig.run_settings.cypress_config_filename));
+  try {
+    let cypressConfigFile = undefined;
+    if (bsConfig.run_settings.cypressTestSuiteType === Constants.CYPRESS_V10_AND_ABOVE_TYPE) {
+      if (bsConfig.run_settings.cypress_config_filename.endsWith("cypress.config.js")) {
+        if (bsConfig.run_settings.cypress_config_file && bsConfig.run_settings.cypress_config_filename !== 'false') {
+          cypressConfigFile = require(path.resolve(bsConfig.run_settings.cypressConfigFilePath));
+        } else if (bsConfig.run_settings.cypressProjectDir) {
+          cypressConfigFile = require(path.join(bsConfig.run_settings.cypressProjectDir, bsConfig.run_settings.cypress_config_filename));
+        }
+      } else {
+        cypressConfigFile = {};
       }
     } else {
-      cypressConfigFile = {};
+      if (bsConfig.run_settings.cypress_config_file && bsConfig.run_settings.cypress_config_filename !== 'false') {
+        cypressConfigFile = JSON.parse(fs.readFileSync(bsConfig.run_settings.cypressConfigFilePath))
+      } else if (bsConfig.run_settings.cypressProjectDir) {
+        cypressConfigFile = JSON.parse(fs.readFileSync(path.join(bsConfig.run_settings.cypressProjectDir, bsConfig.run_settings.cypress_config_filename)));
+      }
     }
-  } else {
-    if (bsConfig.run_settings.cypress_config_file && bsConfig.run_settings.cypress_config_filename !== 'false') {
-      cypressConfigFile = JSON.parse(fs.readFileSync(bsConfig.run_settings.cypressConfigFilePath))
-    } else if (bsConfig.run_settings.cypressProjectDir) {
-      cypressConfigFile = JSON.parse(fs.readFileSync(path.join(bsConfig.run_settings.cypressProjectDir, bsConfig.run_settings.cypress_config_filename)));
-    }
+    return cypressConfigFile;
+  } catch (err) {
+    return {}
   }
-  return cypressConfigFile;
 }
 
 exports.setCLIMode = (bsConfig, args) => {


### PR DESCRIPTION
We are exiting the CLI process with an error code even if no build artifacts were generated or uploaded. In such cases, we can log a warning message and not exit with an error code. This PR does the same thing.