### PR TITLE
1.26.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
🐛 Fix support for yml attribute accessibilityOptions. https://github.com/browserstack/browserstack-cypress-cli/pull/729