### PR TITLE
1.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.26.2",
+  "version": "1.27.0",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* ❇️ Introducing enforce_settings config in run_settings of browserstack.json, which reduces the time taken in build creation. https://github.com/browserstack/browserstack-cypress-cli/pull/741

* 🐛 Omit browserstack-cypress-cli args when running observability tests locally. https://github.com/browserstack/browserstack-cypress-cli/pull/735

* 🐛 Observability build stop improvements to reduce build timeouts. https://github.com/browserstack/browserstack-cypress-cli/pull/742