### PR TITLE
Fix Specs Array Case for Enforce_Settings MAC

### DIFF
--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -1327,7 +1327,7 @@ exports.setEnforceSettingsConfig = (bsConfig) => {
     if(specConfigs && specConfigs.includes(',')) {
       specConfigs = JSON.stringify(specConfigs.split(','));
     }
-    let spec_pattern_args = 'specPattern="'+specConfigs+'"';
+    let spec_pattern_args = `specPattern=${specConfigs}`;
     config_args = this.isUndefined(config_args) ? spec_pattern_args : config_args + ',' + spec_pattern_args;
   }
   if ( this.isNotUndefined(config_args) ) bsConfig["run_settings"]["config"] = config_args;

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -3107,7 +3107,7 @@ describe('utils', () => {
         run_settings: { specs: 'somerandomspecs', cypressTestSuiteType: 'CYPRESS_V10_AND_ABOVE_TYPE' },
       };
       let args = {
-        config: 'video=false,videoUploadOnPasses=false,specPattern="somerandomspecs"'
+        config: 'video=false,videoUploadOnPasses=false,specPattern=somerandomspecs'
       }
       utils.setEnforceSettingsConfig(bsConfig);
       expect(args.config).to.be.eql(bsConfig.run_settings.config);
@@ -3117,7 +3117,7 @@ describe('utils', () => {
         run_settings: { specs: 'somerandomspecs1,somerandomspecs2', cypressTestSuiteType: 'CYPRESS_V10_AND_ABOVE_TYPE' },
       };
       let args = {
-        config: 'video=false,videoUploadOnPasses=false,specPattern="["somerandomspecs1","somerandomspecs2"]"'
+        config: 'video=false,videoUploadOnPasses=false,specPattern=["somerandomspecs1","somerandomspecs2"]'
       }
       utils.setEnforceSettingsConfig(bsConfig);
       expect(args.config).to.be.eql(bsConfig.run_settings.config);


### PR DESCRIPTION
Description:
- When SpecPattern value passed as an array, it fails only for mac. This is to fix it.
- Before - from CLI: ```video=true,videoUploadOnPasses=true,specPattern="["cypress/e2e/1-getting-started/basic.cy.js","cypress/e2e/1-getting-started/skip.cy.js","cypress/e2e/1-getting-started/todo1.spec.js","cypress/e2e/1-getting-started/pending.cy.js"]"```
- Before - in Rails it parsed to: ```--config 'video=true,videoUploadOnPasses=true,specPattern=\"[\"cypress/e2e/1-getting-started/basic.cy.js\",\"cypress/e2e/1-getting-started/skip.cy.js\",\"cypress/e2e/1-getting-started/todo1.spec.js\",\"cypress/e2e/1-getting-started/pending.cy.js\"]\"'```
- This fails due to the escaped double quotes which it tries to search as string.
- Corrected to: ```video=true,videoUploadOnPasses=true,specPattern=["cypress/e2e/1-getting-started/basic.cy.js","cypress/e2e/1-getting-started/skip.cy.js","cypress/e2e/1-getting-started/todo1.spec.js","cypress/e2e/1-getting-started/pending.cy.js"]```
- Rails: ```'video=true,videoUploadOnPasses=true,specPattern=[\"cypress/e2e/1-getting-started/basic.cy.js\",\"cypress/e2e/1-getting-started/skip.cy.js\",\"cypress/e2e/1-getting-started/todo1.spec.js\",\"cypress/e2e/1-getting-started/pending.cy.js\"]'```