### PR TITLE
1.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* ❇️ Support for running cypress sessions on Automate Turboscale. https://github.com/browserstack/browserstack-cypress-cli/pull/736

* 🐛 Fix specs array case for enforce_settings in mac. https://github.com/browserstack/browserstack-cypress-cli/pull/762