### PR TITLE
1.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- 🐛 Added testObservabilityOptions for Observability https://github.com/browserstack/browserstack-cypress-cli/pull/768
- 🐛 Added Observability support for mono repo setups https://github.com/browserstack/browserstack-cypress-cli/pull/769
- 🐛 Added Accessibility support for mono repo setups https://github.com/browserstack/browserstack-cypress-cli/pull/770