### PR TITLE
update: a11y stability changes

### DIFF
--- a/bin/accessibility-automation/cypress/index.js
+++ b/bin/accessibility-automation/cypress/index.js
@@ -281,18 +281,6 @@ Cypress.on('command:start', async (command) => {
 afterEach(() => {
   const attributes = Cypress.mocha.getRunner().suite.ctx.currentTest;
   cy.window().then(async (win) => {
-    cy.wrap(new Promise((resolve) => {
-      setTimeout(async () => {
-        resolve();
-      }, 5000);
-    }), {timeout: 20000}).then(() => {
-      cy.wrap(new Promise((resolve) => {
-        setTimeout(async () => {
-          resolve();
-        }, 5000);
-      }), {timeout: 20000})
-    })
-
     let shouldScanTestForAccessibility = shouldScanForAccessibility(attributes);
     if (!shouldScanTestForAccessibility) return;
 

--- a/bin/accessibility-automation/cypress/index.js
+++ b/bin/accessibility-automation/cypress/index.js
@@ -277,7 +277,7 @@ Cypress.on('command:start', async (command) => {
   if (!shouldScanTestForAccessibility) return;
 
   cy.window().then((win) => {
-    browserStackLog('Performsing scan form command ' + command.attributes.name);
+    browserStackLog('Performing scan form command ' + command.attributes.name);
     cy.wrap(performScan(win, {method: command.attributes.name}), {timeout: 30000});
   })
 })

--- a/bin/accessibility-automation/cypress/index.js
+++ b/bin/accessibility-automation/cypress/index.js
@@ -334,7 +334,7 @@ afterEach(() => {
   });
 })
 
-Cypress.Commands.add('perfromScan', () => {
+Cypress.Commands.add('performScan', () => {
   cy.window().then(async (win) => {
     await performScan(win);
     return await getAccessibilityResultsSummary(win);

--- a/bin/accessibility-automation/cypress/index.js
+++ b/bin/accessibility-automation/cypress/index.js
@@ -282,7 +282,7 @@ afterEach(() => {
   const attributes = Cypress.mocha.getRunner().suite.ctx.currentTest;
   cy.window().then(async (win) => {
     let shouldScanTestForAccessibility = shouldScanForAccessibility(attributes);
-    if (!shouldScanTestForAccessibility) return;
+    if (!shouldScanTestForAccessibility) return cy.wrap({});
 
     cy.wrap(performScan(win), {timeout: 30000}).then(() => {
       try {
@@ -323,39 +323,51 @@ afterEach(() => {
 })
 
 Cypress.Commands.add('performScan', () => {
-  cy.window().then(async (win) => {
-    await performScan(win);
-    return await getAccessibilityResultsSummary(win);
-  });
+  try {
+    const attributes = Cypress.mocha.getRunner().suite.ctx.currentTest || Cypress.mocha.getRunner().suite.ctx._runnable;
+    const shouldScanTestForAccessibility = shouldScanForAccessibility(attributes);
+    if (!shouldScanTestForAccessibility) {
+      console.log(`Not a Accessibility Automation session, cannot perform scan.`);
+      return cy.wrap({});
+    }
+    cy.window().then(async (win) => {
+      await performScan(win);
+      return await getAccessibilityResultsSummary(win);
+    });
+  } catch {}
 })
 
 Cypress.Commands.add('getAccessibilityResultsSummary', () => {
   try {
-    if (Cypress.env("IS_ACCESSIBILITY_EXTENSION_LOADED") !== "true") {
-      console.log(`Not a Accessibility Automation session, cannot retrieve Accessibility results.`);
-      return
+    const attributes = Cypress.mocha.getRunner().suite.ctx.currentTest || Cypress.mocha.getRunner().suite.ctx._runnable;
+    const shouldScanTestForAccessibility = shouldScanForAccessibility(attributes);
+    if (!shouldScanTestForAccessibility) {
+      console.log(`Not a Accessibility Automation session, cannot retrieve Accessibility results summary.`);
+      return cy.wrap({});
     }
-      cy.window().then(async (win) => {
-        await performScan(win);
-        return await getAccessibilityResultsSummary(win);
-      });
+    cy.window().then(async (win) => {
+      await performScan(win);
+      return await getAccessibilityResultsSummary(win);
+    });
   } catch {}
   
 });
 
 Cypress.Commands.add('getAccessibilityResults', () => {
   try {
-    if (Cypress.env("IS_ACCESSIBILITY_EXTENSION_LOADED") !== "true") {
+    const attributes = Cypress.mocha.getRunner().suite.ctx.currentTest || Cypress.mocha.getRunner().suite.ctx._runnable;
+    const shouldScanTestForAccessibility = shouldScanForAccessibility(attributes);
+    if (!shouldScanTestForAccessibility) {
       console.log(`Not a Accessibility Automation session, cannot retrieve Accessibility results.`);
-      return 
+      return cy.wrap({});
     }
 
 /* browserstack_accessibility_automation_script */
 
-      cy.window().then(async (win) => {
-        await performScan(win);
-        return await getAccessibilityResults(win);
-      });
+    cy.window().then(async (win) => {
+      await performScan(win);
+      return await getAccessibilityResults(win);
+    });
 
   } catch {}
   

--- a/bin/accessibility-automation/helper.js
+++ b/bin/accessibility-automation/helper.js
@@ -66,7 +66,10 @@ exports.createAccessibilityTestRun = async (user_config, framework) => {
       'source': {
         frameworkName: "Cypress",
         frameworkVersion: helper.getPackageVersion('cypress', user_config),
-        sdkVersion: helper.getAgentVersion()
+        sdkVersion: helper.getAgentVersion(),
+        language: 'javascript',
+        testFramework: 'cypress',
+        testFrameworkVersion: helper.getPackageVersion('cypress', user_config)
       },
       'settings': settings,
       'versionControl': await helper.getGitMetaData(),
@@ -92,7 +95,7 @@ exports.createAccessibilityTestRun = async (user_config, framework) => {
     };
 
     const response = await nodeRequest(
-      'POST', 'test_runs', data, config, API_URL
+      'POST', 'v2/test_runs', data, config, API_URL
     );
     if(!utils.isUndefined(response.data)) {
       process.env.BS_A11Y_JWT = response.data.data.accessibilityToken;

--- a/bin/accessibility-automation/plugin/index.js
+++ b/bin/accessibility-automation/plugin/index.js
@@ -3,8 +3,10 @@ const path = require("node:path");
 
 const browserstackAccessibility = (on, config) => {
   let browser_validation = true;
-  config.env.BROWSERSTACK_LOGS = 'true';
-  process.env.BROWSERSTACK_LOGS = 'true';
+  if (process.env.BROWSERSTACK_ACCESSIBILITY_DEBUG === 'true') {
+    config.env.BROWSERSTACK_LOGS = 'true';
+    process.env.BROWSERSTACK_LOGS = 'true';
+  }
   on('task', {
     browserstack_log(message) {
       console.log(message)

--- a/bin/accessibility-automation/plugin/index.js
+++ b/bin/accessibility-automation/plugin/index.js
@@ -3,9 +3,17 @@ const path = require("node:path");
 
 const browserstackAccessibility = (on, config) => {
   let browser_validation = true;
+  config.env.BROWSERSTACK_LOGS = 'true';
+  process.env.BROWSERSTACK_LOGS = 'true';
+  on('task', {
+    browserstack_log(message) {
+      console.log(message)
+
+      return null
+    },
+  })
   on('before:browser:launch', (browser = {}, launchOptions) => {
     try {
-
       if (process.env.ACCESSIBILITY_EXTENSION_PATH !== undefined) {
         if (browser.name !== 'chrome') {
           console.log(`Accessibility Automation will run only on Chrome browsers.`);

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -165,7 +165,7 @@ const getAccessibilityPlatforms = (bsConfig) => {
   }
   browserList.forEach((browserDetails, idx) => {
     accessibilityPlatforms[idx] = (browserDetails.accessibility === undefined) ? rootLevelAccessibility : browserDetails.accessibility;
-    if (browserDetails.browser !== 'chrome') {
+    if (browserDetails.browser && browserDetails.browser.toLowerCase() !== 'chrome') {
       logger.warn(`Accessibility Automation will run only on Chrome browsers for ${browserDetails.platform}.`);
     } else if (browserDetails.version && (!browserDetails.version.includes('latest') || browserDetails.version < 94)) {
       logger.warn(`Accessibility Automation will run only on Chrome browser version greater than 94 for ${browserDetails.platform}.`);

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -122,7 +122,7 @@ const caps = (bsConfig, zip) => {
       }
 
       if (process.env.BROWSERSTACK_TEST_ACCESSIBILITY === 'true') {
-        bsConfig.run_settings["accessibilityPlatforms"] = getAccessibilityPlatforms(bsConfig);
+        bsConfig.run_settings["accessibilityPlatforms"] = getAccessibilityPlatforms(bsConfig, obj);
       }
 
       // send run_settings as is for other capabilities
@@ -146,8 +146,8 @@ const caps = (bsConfig, zip) => {
     resolve(data);
   })
 }
-const getAccessibilityPlatforms = (bsConfig) => {
-  const browserList = bsConfig.browsers;
+const getAccessibilityPlatforms = (bsConfig, obj) => {
+  const browserList = obj.devices;
   const accessibilityPlatforms = Array(browserList.length).fill(false);
   let rootLevelAccessibility = false;
   if (!Utils.isUndefined(bsConfig.run_settings.accessibility)) {

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -165,7 +165,7 @@ const getAccessibilityPlatforms = (bsConfig) => {
   }
   browserList.forEach((browserDetails, idx) => {
     accessibilityPlatforms[idx] = (browserDetails.accessibility === undefined) ? rootLevelAccessibility : browserDetails.accessibility;
-    if (browserDetails.name !== 'chrome') {
+    if (browserDetails.browser !== 'chrome') {
       logger.warn(`Accessibility Automation will run only on Chrome browsers for ${browserDetails.platform}.`);
     } else if (browserDetails.version && (!browserDetails.version.includes('latest') || browserDetails.version < 94)) {
       logger.warn(`Accessibility Automation will run only on Chrome browser version greater than 94 for ${browserDetails.platform}.`);

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -165,9 +165,11 @@ const getAccessibilityPlatforms = (bsConfig) => {
   }
   browserList.forEach((browserDetails, idx) => {
     accessibilityPlatforms[idx] = (browserDetails.accessibility === undefined) ? rootLevelAccessibility : browserDetails.accessibility;
-    if (browserDetails.browser && browserDetails.browser.toLowerCase() !== 'chrome') {
+    if (Utils.isUndefined(bsConfig.run_settings.headless) || !(String(bsConfig.run_settings.headless) === "false")) {
+      logger.warn(`Accessibility Automation will not run on legacy headless mode. Switch to new headless mode or avoid using headless mode for ${browserDetails.platform}.`);
+    } else if (browserDetails.browser && browserDetails.browser.toLowerCase() !== 'chrome') {
       logger.warn(`Accessibility Automation will run only on Chrome browsers for ${browserDetails.platform}.`);
-    } else if (browserDetails.version && (!browserDetails.version.includes('latest') || browserDetails.version < 94)) {
+    } else if (browserDetails.version && !browserDetails.version.includes('latest') && browserDetails.version <= 94) {
       logger.warn(`Accessibility Automation will run only on Chrome browser version greater than 94 for ${browserDetails.platform}.`);
     }
   });

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -165,7 +165,9 @@ const getAccessibilityPlatforms = (bsConfig) => {
   }
   browserList.forEach((browserDetails, idx) => {
     accessibilityPlatforms[idx] = (browserDetails.accessibility === undefined) ? rootLevelAccessibility : browserDetails.accessibility;
-    if (browserDetails.version && (!browserDetails.version.includes('latest') || browserDetails.version < 94)) {
+    if (browserDetails.name !== 'chrome') {
+      logger.warn(`Accessibility Automation will run only on Chrome browsers for ${browserDetails.platform}.`);
+    } else if (browserDetails.version && (!browserDetails.version.includes('latest') || browserDetails.version < 94)) {
       logger.warn(`Accessibility Automation will run only on Chrome browser version greater than 94 for ${browserDetails.platform}.`);
     }
   });

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -122,6 +122,8 @@ const caps = (bsConfig, zip) => {
       }
 
       if (process.env.BROWSERSTACK_TEST_ACCESSIBILITY === 'true') {
+        // If any of the platform has accessibility true, make it true
+        bsConfig.run_settings["accessibility"] = true;
         bsConfig.run_settings["accessibilityPlatforms"] = getAccessibilityPlatforms(bsConfig);
       }
 

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -561,6 +561,7 @@ exports.setSystemEnvs = (bsConfig) => {
 
   try {
     const accessibilityOptions = bsConfig.run_settings.accessibilityOptions;
+    envKeys['BROWSERSTACK_ACCESSIBILITY_DEBUG'] = process.env.BROWSERSTACK_ACCESSIBILITY_DEBUG;
     if (accessibilityOptions) {
       Object.keys(accessibilityOptions).forEach(key => {
         const a11y_env_key = `ACCESSIBILITY_${key.toUpperCase()}`


### PR DESCRIPTION
Adding stability v2 changes for accessibility.

- Fix accessiblity run for versions array. (versions: ['latest', 'latest-1'])
- Update accessibility build start api to v2, to get the updated extension version.
- Update scripts for accessibility scan, save results, get results and get results summary.
- Add BROWSERSTACK_ACCESSIBLITY_DEBUG environment variable to have debug logs.
- Use cy.wrap to chain the accessibility promises.
- Add warning message for headless and chrome version. < 94 for accessibility.