### PR TITLE
1.28.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- 🐛 Fixed support for custom config file with --ccf flag for Test Observability & Accessibility https://github.com/browserstack/browserstack-cypress-cli/pull/779