### PR TITLE
1.29.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- ❇️ Introducing Browserstack Accessibility support for Typescript Cypress tests! https://github.com/browserstack/browserstack-cypress-cli/pull/786
- 🐛 Command line arguments are now honored when running Cypress tests with Browserstack Observability. https://github.com/browserstack/browserstack-cypress-cli/pull/792