### PR TITLE
Handling processing of custom config file when provided in browserstack.json or directly via args

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -277,6 +277,7 @@ module.exports = function run(args, rawArgs) {
             logger.debug("Started uploading the node_module zip");
             markBlockStart('zip.zipUpload');
             return zipUploader.zipUpload(bsConfig, md5data, packageData).then(async function (zip) {
+              utils.deleteTmpTestSuiteDir(bsConfig.run_settings);
               logger.debug("Completed uploading the test suite zip");
               logger.debug("Completed uploading the node_module zip");
               markBlockEnd('zip.zipUpload');

--- a/bin/helpers/archiver.js
+++ b/bin/helpers/archiver.js
@@ -6,7 +6,8 @@ const fs = require("fs"),
 const archiver = require("archiver"),
   Constants = require('../helpers/constants'),
   logger = require("./logger").winstonLogger,
-  utils = require('../helpers/utils');
+  utils = require('../helpers/utils'),
+  { updateConfig } = require('../helpers/readCypressConfigUtil');
 
 const archiveSpecs = (runSettings, filePath, excludeFiles, md5data) => {
   return new Promise(function (resolve, reject) {
@@ -27,8 +28,15 @@ const archiveSpecs = (runSettings, filePath, excludeFiles, md5data) => {
     } else {
       cypressFolderPath = path.dirname(runSettings.cypressConfigFilePath);
     }
-
     logger.info(`Creating tests.zip with files in ${cypressFolderPath}`);
+    if (
+      runSettings.cypress_config_file &&
+      runSettings.cypress_config_filename !== 'false'
+    ) {
+      cypressFolderPath = utils.createTmpTestSuiteDir(runSettings);
+      logger.debug(`Created temp directory for test suite: ${cypressFolderPath}`);
+      updateConfig(runSettings, path.join(config.tmpTestSuiteDirName, cypressAppendFilesZipLocation));
+    }
 
     var archive = archiver('zip', {
       zlib: {level: 9}, // Sets the compression level.

--- a/bin/helpers/config.js
+++ b/bin/helpers/config.js
@@ -26,6 +26,7 @@ config.retries = 5;
 config.networkErrorExitCode = 2;
 config.compiledConfigJsDirName = 'tmpBstackCompiledJs';
 config.configJsonFileName = 'tmpCypressConfig.json';
+config.tmpTestSuiteDirName = 'tmpTestSuite';
 
 // turboScale
 config.turboScaleMd5Sum = `${config.turboScaleUrl}/md5sumcheck`;

--- a/bin/helpers/readCypressConfigUtil.js
+++ b/bin/helpers/readCypressConfigUtil.js
@@ -13,6 +13,18 @@ exports.detectLanguage = (cypress_config_filename) => {
     return constants.CYPRESS_V10_AND_ABOVE_CONFIG_FILE_EXTENSIONS.includes(extension) ? extension : 'js'
 }
 
+exports.updateConfig = (runSettings, cypressAppendFilesZipLocation) => {
+    logger.debug(`Updating cypress config based on provided cypress config file: ${runSettings.cypress_config_filename}`);
+    for (const possibleCypressFileName of constants.CYPRESS_CONFIG_FILE_NAMES) {
+        if (path.extname(runSettings.cypress_config_filename) == path.extname(possibleCypressFileName)) {
+            const cypressFilePath = path.join(cypressAppendFilesZipLocation, possibleCypressFileName);
+            const configData = fs.readFileSync(runSettings.cypressConfigFilePath, {encoding: "utf-8"});
+            fs.writeFileSync(cypressFilePath, configData);
+            break;
+        }
+    }
+}
+
 exports.convertTsConfig = (bsConfig, cypress_config_filepath, bstack_node_modules_path) => {
     const cypress_config_filename = bsConfig.run_settings.cypress_config_filename
     const working_dir = path.dirname(cypress_config_filepath);


### PR DESCRIPTION
Issue:
For typescript projects, when any custom file is provided for cypress config, it was not getting picked when a default config file with the name `cypress.confg.ts` was also present. It always picked the default config file irrespective of the arguments provided or file path mentioned in the `browserstack.json` file.

Fix:

1. Before starting the archiving process, Create a temp test suite dir with all the contents from home dir of the project
2. Copy the contents of the required config file to `cypress.config.ts`/`cypress.config.ts` in the temp dir.
3. After archiving and zips upload is completed, delete the temp test suite dir.