### PR TITLE
1.29.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- 🐛 Fix for force upload failure on Turboscale. https://github.com/browserstack/browserstack-cypress-cli/pull/801
- ❇️ Added instrumentation for Turboscale sessions. https://github.com/browserstack/browserstack-cypress-cli/pull/806