### PR TITLE
1.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- ❇️ Add support for capturing the response payload for network requests in the test session. https://github.com/browserstack/browserstack-cypress-cli/pull/829