### PR TITLE
1.31.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- ❇️ Limit VCS info to 64kb https://github.com/browserstack/browserstack-cypress-cli/pull/834