### PR TITLE
1.31.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.31.6",
+  "version": "1.31.7",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
❇️ Add support for Windows and Mac specific npm dependencies. https://github.com/browserstack/browserstack-cypress-cli/pull/867