### PR TITLE
1 fixed Vulnerability in the code - BrowserStack

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "browserstack-cypress": "bin/runner.js"
   },
   "dependencies": {
-    "archiver": "5.3.0",
+    "archiver": "7.0.0",
     "async": "3.2.3",
     "browserstack-local": "1.5.4",
     "chalk": "4.1.2",
@@ -22,7 +22,7 @@
     "git-last-commit": "^1.0.1",
     "git-repo-info": "^2.1.1",
     "gitconfiglocal": "^2.1.0",
-    "glob": "^7.2.0",
+    "glob": "^9.0.0",
     "mocha": "^10.2.0",
     "mkdirp": "1.0.4",
     "node-ipc": "9.1.1",


### PR DESCRIPTION
Summary:
The NPM Package code (package.json) is affected with CWE-772: Missing Release of Resource after Effective Lifetime

CWE Details:
CWE-772: Missing Release of Resource after Effective Lifetime

Severity:
Medium

Description:
The product does not release a resource after its effective lifetime has ended, i.e., after the resource is no longer needed.
 
Extended Description:
When a resource is not released after use, it can allow attackers to cause a denial of service by causing the allocation of resources without triggering their release. Frequently-affected resources include memory, CPU, disk space, power or battery, etc. 

Changes Applied:
Updated packages vulnerable versions used in the code.

==================================================================================

Overview

Affected versions of this package are vulnerable to Missing Release of Resource after Effective Lifetime via the makeres function due to improperly deleting keys from the reqs object after execution of callbacks. This behavior causes the keys to remain in the reqs object, which leads to resource exhaustion.

Exploiting this vulnerability results in crashing the node process or in the application crash.

Note: This library is not maintained, and currently, there is no fix for this issue. To overcome this vulnerability, several dependent packages have eliminated the use of this library.

To trigger the memory leak, an attacker would need to have the ability to execute or influence the asynchronous operations that use the inflight module within the application. This typically requires access to the internal workings of the server or application, which is not commonly exposed to remote users. Therefore, “Attack vector” is marked as “Local”.

 Detailed paths:

 -   Introduced through: browserstack-cypress-cli@1.31.8 › mocha@10.7.3 › glob@8.1.0 › inflight@1.0.6
 -   Introduced through: browserstack-cypress-cli@1.31.8 › browserstack-local@1.5.4 › temp-fs@0.9.9 › rimraf@2.5.4 › glob@7.2.3 › inflight@1.0.6
  

