### PR TITLE
Custom Report Support for Automate Turboscale

### DIFF
--- a/bin/commands/generateReport.js
+++ b/bin/commands/generateReport.js
@@ -6,7 +6,7 @@ const logger = require("../helpers/logger").winstonLogger,
       reporterHTML = require('../helpers/reporterHTML'),
       getInitialDetails = require('../helpers/getInitialDetails').getInitialDetails;
 const { isTurboScaleSession } = require('../helpers/atsHelper');
-      
+
 module.exports = function generateReport(args, rawArgs) {
   let bsConfigPath = utils.getConfigPath(args.cf);
   let reportGenerator = reporterHTML.reportGenerator;

--- a/bin/commands/generateReport.js
+++ b/bin/commands/generateReport.js
@@ -5,13 +5,13 @@ const logger = require("../helpers/logger").winstonLogger,
       utils = require("../helpers/utils"),
       reporterHTML = require('../helpers/reporterHTML'),
       getInitialDetails = require('../helpers/getInitialDetails').getInitialDetails;
-
-
+const { isTurboScaleSession } = require('../helpers/atsHelper');
+      
 module.exports = function generateReport(args, rawArgs) {
   let bsConfigPath = utils.getConfigPath(args.cf);
   let reportGenerator = reporterHTML.reportGenerator;
 
-  return utils.validateBstackJson(bsConfigPath).then(function (bsConfig) {
+  return utils.validateBstackJson(bsConfigPath).then(async function (bsConfig) {
     // setting setDefaults to {} if not present and set via env variables or via args.
     utils.setDefaults(bsConfig, args);
 
@@ -21,9 +21,9 @@ module.exports = function generateReport(args, rawArgs) {
     // accept the access key from command line if provided
     utils.setAccessKey(bsConfig, args);
 
-    getInitialDetails(bsConfig, args, rawArgs).then((buildReportData) => {
-
-      utils.setUsageReportingFlag(bsConfig, args.disableUsageReporting);
+    try {
+      let buildReportData = isTurboScaleSession(bsConfig) ? null : await getInitialDetails(bsConfig, args, rawArgs);
+       utils.setUsageReportingFlag(bsConfig, args.disableUsageReporting);
   
       // set cypress config filename
       utils.setCypressConfigFilename(bsConfig, args);
@@ -34,9 +34,9 @@ module.exports = function generateReport(args, rawArgs) {
   
       reportGenerator(bsConfig, buildId, args, rawArgs, buildReportData);
       utils.sendUsageReport(bsConfig, args, 'generate-report called', messageType, errorCode, buildReportData, rawArgs);
-    }).catch((err) => {
+    } catch(err) {
       logger.warn(err);
-    });
+    };
   }).catch(function (err) {
     logger.error(err);
     utils.setUsageReportingFlag(null, args.disableUsageReporting);

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -366,7 +366,7 @@ module.exports = function run(args, rawArgs) {
 
                     // download build artifacts
                     if (exitCode != Constants.BUILD_FAILED_EXIT_CODE) {
-                      if (utils.nonEmptyArray(bsConfig.run_settings.downloads)) {
+                      if (utils.nonEmptyArray(bsConfig.run_settings.downloads) && !turboScaleSession) {
                         logger.debug("Downloading build artifacts");
                         await downloadBuildArtifacts(bsConfig, data.build_id, args, rawArgs, buildReportData);
                       }

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -365,7 +365,7 @@ module.exports = function run(args, rawArgs) {
                     await new Promise(resolve => setTimeout(resolve, 5000));
 
                     // download build artifacts
-                    if (exitCode != Constants.BUILD_FAILED_EXIT_CODE && !turboScaleSession) {
+                    if (exitCode != Constants.BUILD_FAILED_EXIT_CODE) {
                       if (utils.nonEmptyArray(bsConfig.run_settings.downloads)) {
                         logger.debug("Downloading build artifacts");
                         await downloadBuildArtifacts(bsConfig, data.build_id, args, rawArgs, buildReportData);

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -131,8 +131,8 @@ const caps = (bsConfig, zip) => {
       obj.run_settings = JSON.stringify(bsConfig.run_settings);
     }
 
-    obj.cypress_cli_version = Utils.getUserAgent();
-    logger.info(`Cypress CLI User Agent: ${obj.cypress_cli_version}`);
+    obj.cypress_cli_user_agent = Utils.getUserAgent();
+    logger.info(`Cypress CLI User Agent: ${obj.cypress_cli_user_agent}`);
 
     if(obj.parallels === Constants.cliMessages.RUN.DEFAULT_PARALLEL_MESSAGE) obj.parallels = undefined
 

--- a/bin/helpers/capabilityHelper.js
+++ b/bin/helpers/capabilityHelper.js
@@ -131,6 +131,9 @@ const caps = (bsConfig, zip) => {
       obj.run_settings = JSON.stringify(bsConfig.run_settings);
     }
 
+    obj.cypress_cli_version = Utils.getUserAgent();
+    logger.info(`Cypress CLI User Agent: ${obj.cypress_cli_version}`);
+
     if(obj.parallels === Constants.cliMessages.RUN.DEFAULT_PARALLEL_MESSAGE) obj.parallels = undefined
 
     if (obj.project) logger.info(`Project name is: ${obj.project}`);

--- a/bin/helpers/config.js
+++ b/bin/helpers/config.js
@@ -29,6 +29,6 @@ config.configJsonFileName = 'tmpCypressConfig.json';
 
 // turboScale
 config.turboScaleMd5Sum = `${config.turboScaleUrl}/md5sumcheck`;
-config.turboScaleBuildsUrl = `${config.turboScaleAPIUrl}/builds`;
+config.turboScaleBuildsUrl = `${config.turboScaleUrl}/builds`;
 
 module.exports = config;

--- a/bin/helpers/config.js
+++ b/bin/helpers/config.js
@@ -29,6 +29,6 @@ config.configJsonFileName = 'tmpCypressConfig.json';
 
 // turboScale
 config.turboScaleMd5Sum = `${config.turboScaleUrl}/md5sumcheck`;
-config.turboScaleBuildsUrl = `${config.turboScaleUrl}/builds`;
+config.turboScaleBuildsUrl = `${config.turboScaleAPIUrl}/builds`;
 
 module.exports = config;

--- a/bin/helpers/config.json
+++ b/bin/helpers/config.json
@@ -4,6 +4,6 @@
   "dashboardUrl": "https://automate.browserstack.com/dashboard/v2/builds/",
   "usageReportingUrl": "https://eds.browserstack.com:443/send_event_cy_internal",
   "localTestingListUrl": "https://www.browserstack.com/local/v1/list",
-  "turboScaleUrl": "http://grid-api-devhst.bsstag.com/packages/cypress",
-  "turboScaleAPIUrl": "http://grid-api-devhst.bsstag.com/automate-turboscale/v1"
+  "turboScaleUrl": "https://grid.browserstack.com/packages/cypress",
+  "turboScaleAPIUrl": "https://api.browserstack.com/automate-turboscale/v1"
 }

--- a/bin/helpers/config.json
+++ b/bin/helpers/config.json
@@ -4,6 +4,6 @@
   "dashboardUrl": "https://automate.browserstack.com/dashboard/v2/builds/",
   "usageReportingUrl": "https://eds.browserstack.com:443/send_event_cy_internal",
   "localTestingListUrl": "https://www.browserstack.com/local/v1/list",
-  "turboScaleUrl": "https://grid.browserstack.com/packages/cypress",
-  "turboScaleAPIUrl": "https://api.browserstack.com/automate-turboscale/v1"
+  "turboScaleUrl": "http://grid-api-devhst.bsstag.com/packages/cypress",
+  "turboScaleAPIUrl": "http://grid-api-devhst.bsstag.com/automate-turboscale/v1"
 }

--- a/bin/helpers/reporterHTML.js
+++ b/bin/helpers/reporterHTML.js
@@ -19,6 +19,10 @@ let reportGenerator = (bsConfig, buildId, args, rawArgs, buildReportData, cb) =>
     },
   };
 
+  if (Constants.turboScaleObj.enabled) {
+    options.url = `${config.turboScaleBuildsUrl}/${buildId}/custom_report`;
+  }
+  
   logger.debug('Started fetching the build json and html reports.');
 
   return request.get(options, async function (err, resp, body) {

--- a/bin/helpers/reporterHTML.js
+++ b/bin/helpers/reporterHTML.js
@@ -6,6 +6,7 @@ const fs = require('fs'),
       Constants = require('./constants'),
       config = require("./config"),
       decompress = require('decompress');
+const { isTurboScaleSession } = require('../helpers/atsHelper');
 
 let reportGenerator = (bsConfig, buildId, args, rawArgs, buildReportData, cb) => {
   let options = {
@@ -19,7 +20,7 @@ let reportGenerator = (bsConfig, buildId, args, rawArgs, buildReportData, cb) =>
     },
   };
 
-  if (Constants.turboScaleObj.enabled) {
+  if (isTurboScaleSession(bsConfig)) {
     options.url = `${config.turboScaleBuildsUrl}/${buildId}/custom_report`;
   }
   


### PR DESCRIPTION
JIRA Story: [HST-1587](https://browserstack.atlassian.net/browse/HST-1587?atlOrigin=eyJpIjoiZWM3NmU3MWE2MDZlNDgwYTkyOWIzYTUyYWI3NTQ0ZDAiLCJwIjoiaiJ9)

merged https://github.com/browserstack/browserstack-cypress-cli/pull/890 - download Artifacts

**Changes:**

1.  Added support for `/custom_report` endpoint to generate HTML/JSON report
2. To add support for generating custom report directly using **generate-report** command in CLI - changed `getInitialDetails` details logic to exclude Automate Turboscale session
3. Also, adding `cypress_cli_user_agent` in caps to store cli version
 
 
 **Release Note:**
 1. Added support for Custom Report and Download Artifacts for Turboscale sessions.

[HST-1587]: https://browserstack.atlassian.net/browse/HST-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ