### PR TITLE
1.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.31.10",
+  "version": "1.32.0",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
❇️ Deprecate `request` library in favor of `axios` https://github.com/browserstack/browserstack-cypress-cli/pull/891