### PR TITLE
HST-972 ATS Cypress Local Support

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -153,11 +153,6 @@ module.exports = function run(args, rawArgs) {
       }
 
       if (turboScaleSession) {
-        // Local is only required in case user is running on trial grid and wants to access private website.
-        // Even then, it will be spawned separately via browserstack-cli ats connect-grid command and not via browserstack-cypress-cli
-        // Hence whenever running on ATS, need to make local as false
-        bsConfig.connection_settings.local = false;
-
         const gridDetails = await getTurboScaleGridDetails(bsConfig, args, rawArgs);
 
         if (gridDetails && Object.keys(gridDetails).length > 0) {


### PR DESCRIPTION
Added Local support on Cypress ATS

JIRA: [HST-972](https://browserstack.atlassian.net/browse/HST-972)

Release Note: 
1. Added support for Local on Automate Turboscale

[HST-972]: https://browserstack.atlassian.net/browse/HST-972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ