### PR TITLE
1.32.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.32.2",
+  "version": "1.32.3",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- 🐛 Fix CLI exit status code in case of report generation failure. https://github.com/browserstack/browserstack-cypress-cli/pull/953
- 🐛 Fix accessibility reporting for test retries. https://github.com/browserstack/browserstack-cypress-cli/pull/956