### PR TITLE
1.32.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.32.6",
+  "version": "1.32.7",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* 🐛 Fixed issue with running sessions on Automate TurboScale from any windows machine. https://github.com/browserstack/browserstack-cypress-cli/pull/975