### PR TITLE
1.32.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.32.7",
+  "version": "1.32.8",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Highlighted Changes 🥳

❇️ Add warning log when passing invalid gridName for Automate TurboScale sessions https://github.com/browserstack/browserstack-cypress-cli/pull/979