### PR TITLE
Remove unused import of 'util' module

### DIFF
--- a/bin/testObservability/cypress/index.js
+++ b/bin/testObservability/cypress/index.js
@@ -2,8 +2,6 @@
 
 /* Used to detect Gherkin steps */
 
-const util = require('util');
-
 let eventsQueue = [];
 let testRunStarted = false;
 


### PR DESCRIPTION
Removed import of unused 'util' module that is not set as a dependency for this repo. 
See issue:
https://github.com/browserstack/browserstack-cypress-cli/issues/1004