### PR TITLE
SDK-6180 Support proxyCaCertificate for SSL-inspecting proxies

### DIFF
--- a/bin/helpers/caCertHelper.js
+++ b/bin/helpers/caCertHelper.js
@@ -92,8 +92,17 @@ function setupCaCertificate(bsConfig) {
       if (!isPem) {
         const os = require('os');
         const path = require('path');
-        nodeExtra = path.join(os.tmpdir(), `browserstack_sdk_ca_${process.pid}.pem`);
-        fs.writeFileSync(nodeExtra, pemCerts.join(''));
+        // Fresh owner-only temp dir (random name) + 0600 + O_EXCL/O_NOFOLLOW: a predictable
+        // path in a world-writable tmpdir would let a local attacker pre-plant or symlink-race
+        // the file the process is about to TRUST as a CA.
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browserstack_sdk_ca_'));
+        nodeExtra = path.join(tmpDir, 'ca.pem');
+        const fd = fs.openSync(nodeExtra, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | (fs.constants.O_NOFOLLOW || 0), 0o600);
+        try {
+          fs.writeFileSync(fd, pemCerts.join(''));
+        } finally {
+          fs.closeSync(fd);
+        }
       }
       process.env.NODE_EXTRA_CA_CERTS = nodeExtra;
     }

--- a/bin/helpers/caCertHelper.js
+++ b/bin/helpers/caCertHelper.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/*
+ * SDK-5953: trust a customer-provided CA certificate for SSL-inspecting corporate
+ * proxies (Zscaler, Netskope, Forcepoint).
+ *
+ * Resolution order for the cert path:
+ *   1. env BROWSERSTACK_EXTRA_CA_CERTS   (consistency with the other SDKs)
+ *   2. browserstack.json connection_settings.proxyCaCertificate
+ *   3. browserstack.json top-level proxyCaCertificate
+ *
+ * The CLI makes outbound HTTPS via axios across many files (some through an
+ * HttpsProxyAgent when a proxy is set, some direct). Rather than patch every
+ * axios call, we patch `tls.createSecureContext` once and `addCACert` the
+ * customer cert — this MERGES it with Node's default roots (never replaces them,
+ * so non-intercepted endpoints still validate) and is honored by every TLS
+ * connection (axios default agent AND the HttpsProxyAgent tunnel). We also export
+ * NODE_EXTRA_CA_CERTS so any child Node processes trust the same cert.
+ *
+ * Never throws — a misconfigured cert must not break the customer's run.
+ */
+
+const tls = require('tls');
+const fs = require('fs');
+const logger = require('./logger').winstonLogger;
+
+let _patched = false;
+
+function _log(level, msg) {
+  try { if (logger && typeof logger[level] === 'function') { logger[level](msg); } } catch (e) { /* ignore */ }
+}
+
+function resolveCaCertPath(bsConfig) {
+  let p = process.env.BROWSERSTACK_EXTRA_CA_CERTS;
+  const cs = (bsConfig && bsConfig.connection_settings) || {};
+  if ((!p || !p.trim()) && cs.proxyCaCertificate) { p = cs.proxyCaCertificate; }
+  if ((!p || !p.trim()) && bsConfig && bsConfig.proxyCaCertificate) { p = bsConfig.proxyCaCertificate; }
+  if (!p || !String(p).trim()) { return null; }
+  p = String(p).trim();
+  try {
+    if (fs.existsSync(p) && fs.statSync(p).isFile()) { return p; }
+    _log('warn', `proxyCaCertificate: path does not exist or is not a file, falling back to system trust store: ${p}`);
+  } catch (e) {
+    _log('warn', `proxyCaCertificate: failed to stat cert path ${p}: ${e.message}`);
+  }
+  return null;
+}
+
+function setupCaCertificate(bsConfig) {
+  if (_patched) { return; }
+  try {
+    const certPath = resolveCaCertPath(bsConfig);
+    if (!certPath) { return; }
+    const caPem = fs.readFileSync(certPath, 'utf8');
+
+    const originalCreateSecureContext = tls.createSecureContext;
+    tls.createSecureContext = function (options = {}) {
+      const context = originalCreateSecureContext(options);
+      try { context.context.addCACert(caPem); } catch (e) { /* best-effort merge */ }
+      return context;
+    };
+
+    if (!process.env.NODE_EXTRA_CA_CERTS) {
+      process.env.NODE_EXTRA_CA_CERTS = certPath;
+    }
+
+    _patched = true;
+    _log('info', `proxyCaCertificate: trusting custom CA from ${certPath} (merged with system roots).`);
+  } catch (e) {
+    _log('warn', `proxyCaCertificate: setup failed, falling back to system trust store: ${e.message}`);
+  }
+}
+
+module.exports = { resolveCaCertPath, setupCaCertificate };

--- a/bin/helpers/caCertHelper.js
+++ b/bin/helpers/caCertHelper.js
@@ -30,6 +30,21 @@ function _log(level, msg) {
   try { if (logger && typeof logger[level] === 'function') { logger[level](msg); } } catch (e) { /* ignore */ }
 }
 
+// Convert a DER (binary) certificate Buffer to a PEM string (base64, 64-char lines).
+function derToPem(der) {
+  const b64 = der.toString('base64').replace(/(.{64})/g, '$1\n');
+  return `-----BEGIN CERTIFICATE-----\n${b64}${b64.endsWith('\n') ? '' : '\n'}-----END CERTIFICATE-----\n`;
+}
+
+// Read a customer CA Buffer into an array of PEM cert strings, supporting BOTH PEM
+// (single or multi-cert bundle) and DER (binary) — any extension (.pem/.crt/.cer/.der).
+function loadCaCertsAsPem(buf) {
+  if (buf.includes('-----BEGIN CERTIFICATE-----')) {
+    return buf.toString('utf8').match(/-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g) || [];
+  }
+  return [derToPem(buf)]; // DER (binary) single cert
+}
+
 function resolveCaCertPath(bsConfig) {
   let p = process.env.BROWSERSTACK_EXTRA_CA_CERTS;
   const cs = (bsConfig && bsConfig.connection_settings) || {};
@@ -51,17 +66,36 @@ function setupCaCertificate(bsConfig) {
   try {
     const certPath = resolveCaCertPath(bsConfig);
     if (!certPath) { return; }
-    const caPem = fs.readFileSync(certPath, 'utf8');
+    const buf = fs.readFileSync(certPath);
+    const isPem = buf.includes('-----BEGIN CERTIFICATE-----');
+    const pemCerts = loadCaCertsAsPem(buf);
+    if (!pemCerts.length) {
+      _log('warn', `proxyCaCertificate: no certificate found in ${certPath}; falling back to system trust store.`);
+      return;
+    }
 
     const originalCreateSecureContext = tls.createSecureContext;
     tls.createSecureContext = function (options = {}) {
       const context = originalCreateSecureContext(options);
-      try { context.context.addCACert(caPem); } catch (e) { /* best-effort merge */ }
+      // addCACert one cert at a time so multi-cert bundles are all trusted.
+      for (const pem of pemCerts) {
+        try { context.context.addCACert(pem); } catch (e) { /* best-effort merge */ }
+      }
       return context;
     };
 
+    // NODE_EXTRA_CA_CERTS must be a PEM file for child Node processes: reuse the
+    // customer's path when it's already PEM, else write a PEM-converted copy (Node
+    // can't load a raw DER file through that var).
     if (!process.env.NODE_EXTRA_CA_CERTS) {
-      process.env.NODE_EXTRA_CA_CERTS = certPath;
+      let nodeExtra = certPath;
+      if (!isPem) {
+        const os = require('os');
+        const path = require('path');
+        nodeExtra = path.join(os.tmpdir(), `browserstack_sdk_ca_${process.pid}.pem`);
+        fs.writeFileSync(nodeExtra, pemCerts.join(''));
+      }
+      process.env.NODE_EXTRA_CA_CERTS = nodeExtra;
     }
 
     _patched = true;
@@ -71,4 +105,4 @@ function setupCaCertificate(bsConfig) {
   }
 }
 
-module.exports = { resolveCaCertPath, setupCaCertificate };
+module.exports = { resolveCaCertPath, setupCaCertificate, loadCaCertsAsPem, derToPem };

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -35,6 +35,9 @@ exports.validateBstackJson = (bsConfigPath) => {
       logger.info(`Reading config from ${bsConfigPath}`);
       let bsConfig = require(bsConfigPath);
       bsConfig = exports.normalizeTestReportingConfig(bsConfig);
+      // SDK-5953: trust the customer CA (proxyCaCertificate / BROWSERSTACK_EXTRA_CA_CERTS)
+      // for all outbound HTTPS (axios) before any request fires. Merged with system roots.
+      try { require('./caCertHelper').setupCaCertificate(bsConfig); } catch (e) { /* never break the run */ }
       resolve(bsConfig);
     } catch (e) {
       reject(


### PR DESCRIPTION
## What is this about?
Adds `proxyCaCertificate` support so the Cypress CLI works behind SSL-inspecting corporate proxies (Zscaler/Netskope/Forcepoint).

- New `proxyCaCertificate` (path to a PEM CA), read from `connection_settings.proxyCaCertificate` (or top-level) in `browserstack.json`; env **`BROWSERSTACK_EXTRA_CA_CERTS`** overrides.
- **Merged** with the system trust store (never replaces).
- Missing/invalid path logs a WARN and falls back to defaults — never breaks the run.

## How
The CLI makes outbound HTTPS via `axios` across ~10 files (some via `HttpsProxyAgent`, some direct), so rather than patch each:
- `bin/helpers/caCertHelper.js` patches `tls.createSecureContext` once and `addCACert`s the customer cert — honored by every axios call and the proxy tunnel, merged with default roots. Also sets `NODE_EXTRA_CA_CERTS`.
- Hooked in `validateBstackJson` (runs first in every command, before any axios call).

## Verification (mitmproxy SSL-inspecting proxy)
Drove the **real** `caCertHelper` + `axios` through mitmproxy: without the cert → `UNABLE_TO_VERIFY_LEAF_SIGNATURE`; with it → success (HTTP 404 through the proxy). Cert-gated: without the cert the CLI still rejects the MITM cert; merge keeps public roots.

## Related Jira
- [SDK-6180](https://browserstack.atlassian.net/browse/SDK-6180) (parent [SDK-5953](https://browserstack.atlassian.net/browse/SDK-5953))

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SDK-6180]: https://browserstack.atlassian.net/browse/SDK-6180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ