### PR TITLE
fix(observability): SDK-6211 — TRA build duration counts post-test CLI work (report-gen + 5s wait)

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -364,6 +364,15 @@ module.exports = function run(args, rawArgs) {
                     // stop the Local instance
                     if (!turboScaleSession) await utils.stopLocalBinary(bsConfig, bs_local, args, rawArgs, buildReportData);
 
+                    // SDK-6211: send the Test Observability build-stop now — polling has resolved, so
+                    // the build has finished running on BrowserStack. builds_th.finished_at is stamped
+                    // server-side when the collector receives this stop event, so firing it here (before
+                    // the 5s safety wait, artifact download and HTML report generation below) keeps the
+                    // TRA build "Duration" aligned with the test window instead of the full CLI wall-clock.
+                    // printBuildLink no-ops on non-observability runs and is idempotent (buildStopped
+                    // guard); the later handleSyncExit stop becomes a no-op that still honors the exit code.
+                    await printBuildLink(true);
+
                     // waiting for 5 secs for upload to complete (as a safety measure)
                     await new Promise(resolve => setTimeout(resolve, 5000));
 

--- a/bin/testObservability/helper/helper.js
+++ b/bin/testObservability/helper/helper.js
@@ -93,7 +93,16 @@ const supportFileCleanup = () => {
 exports.buildStopped = false;
 
 exports.printBuildLink = async (shouldStopSession, exitCode = null) => {
-  if(!this.isTestObservabilitySession() || exports.buildStopped) return;
+  if(!this.isTestObservabilitySession()) return;
+  // SDK-6211: the build-stop may be sent early (runs.js fires it at poll-resolution, before the
+  // post-test 5s wait + artifact download + report generation, so builds_th.finished_at — which
+  // the collector stamps at stop-event receipt — reflects the test window rather than the full CLI
+  // wall-clock). A later call here must therefore still honor the exit code instead of returning
+  // silently, preserving the original failing-build exit behaviour.
+  if(exports.buildStopped) {
+    if(exitCode) process.exit(exitCode);
+    return;
+  }
   exports.buildStopped = true;
   try {
     if(shouldStopSession) {


### PR DESCRIPTION
## Summary
For sync-mode `browserstack-cypress run`, the Test Observability build **Duration** (`builds_th.duration = finished_at − started_at`) is inflated because the build-stop event is sent only **after** post-test CLI work. `builds_th.finished_at` is stamped **server-side when the collector receives the stop event**, and cypress-cli sends it after `stopLocalBinary` + a hard-coded `setTimeout(5000)` + `downloadBuildArtifacts` + `reportGenerator` (`bin/commands/runs.js`). All of that elapsed time gets counted as "test time" (~37s in the reported case, SDK-6211).

This is cypress-cli-specific: node-agent / javaagent / python / binary all fire the build-stop right after a lightweight event drain, **before** any report generation.

## Change
- `bin/commands/runs.js`: fire `await printBuildLink(true)` at poll-resolution (the build has finished running on BrowserStack), **before** the 5s wait + artifact download + report generation.
- `bin/testObservability/helper/helper.js`: split the `printBuildLink` `buildStopped` guard so a later (already-stopped) call still honors the exit code — preserving the original failing-build `process.exit(exitCode)` behaviour.

No new imports; `package-lock.json` untouched; +19/−1.

## Verification (real BrowserStack builds, single-spec sync repro)
| | stop vs report-gen | TRA `finished_at` |
|---|---|---|
| before | report-gen `08:22:35` → **then** stop `08:22:37` | `08:22:37.281` — report **inside** window |
| after | stop `09:24:06` → **then** report-gen `09:24:13` | `09:24:06.469` = stop receipt; report-gen **6.5s after** → **excluded** |

`finished_at` now lands at the stop-event receipt (test completion) rather than after report generation. Passing-build exit code 0 confirmed; failing-build exit preserved by construction (guard mirrors the original `if(exitCode) process.exit(exitCode)` tail).

## Scope / not in this PR
Removes the **post-session** inflation only. The **pre-session** window (`started_at` is server-stamped at the early build-init, which must be sent early to obtain the build id used for session linking) is **unchanged** and is a separate **Observability-backend** concern (define the build window from device-session start) affecting all SDKs — tracked separately. After this fix the reported build drops ~258s→~221s; full alignment with the Automate device-session duration requires the backend change.

Refs: SDK-6211

🤖 Generated with [Claude Code](https://claude.com/claude-code)