### PR TITLE
fix(observability): prevent "Converting circular structure to JSON" crash from circular cy.task payloads [SDK-6016]

### DIFF
--- a/bin/testObservability/cypress/index.js
+++ b/bin/testObservability/cypress/index.js
@@ -6,6 +6,34 @@ const STEP_KEYWORDS = ['given', 'when', 'then', 'and', 'but', '*'];
 let eventsQueue = [];
 let testRunStarted = false;
 
+/*
+ * Command args (command.attributes.args) and cy.log items are captured raw and can hold
+ * circular Cypress runtime objects (e.g. a config-like object whose `renderOptions.host`
+ * points back to itself). cy.task() JSON-serializes its payload to ship it from the browser
+ * to the Node plugin process, so a circular arg makes Cypress throw
+ * "Converting circular structure to JSON" and aborts the run. Decycle the payload before
+ * handing it to cy.task so o11y instrumentation can never break the customer's tests. [SDK-6016]
+ */
+const getCircularReplacer = () => {
+  const seen = new WeakSet();
+  return (key, value) => {
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) return '[Circular]';
+      seen.add(value);
+    }
+    return value;
+  };
+};
+
+const sanitizeForTask = (data) => {
+  try {
+    return JSON.parse(JSON.stringify(data, getCircularReplacer()));
+  } catch (e) {
+    /* Never let serialization of o11y data break the user's test run (graceful degradation). */
+    return { serializationError: e && e.message ? e.message : String(e) };
+  }
+};
+
 const browserStackLog = (message) => {
 
   if (!Cypress.env('BROWSERSTACK_LOGS')) return;
@@ -208,7 +236,7 @@ Cypress.on('command:enqueued', (attrs) => {
   if (args.includes('test_observability_log') || args.includes('test_observability_command')) return;
   const message = args.reduce((result, logItem) => {
     if (typeof logItem === 'object') {
-      return [result, JSON.stringify(logItem)].join(' ');
+      return [result, JSON.stringify(logItem, getCircularReplacer())].join(' ');
     }
     return [result, logItem ? logItem.toString() : ''].join(' ');
   }, '');
@@ -309,7 +337,7 @@ beforeEach(() => {
 
   if (eventsQueue.length > 0) {
     eventsQueue.forEach(event => {
-      cy.task(event.task, event.data, event.options);
+      cy.task(event.task, sanitizeForTask(event.data), event.options);
     });
   }
   eventsQueue = [];
@@ -324,7 +352,7 @@ afterEach(function() {
 
   if (eventsQueue.length > 0) {
     eventsQueue.forEach(event => {
-      cy.task(event.task, event.data, event.options);
+      cy.task(event.task, sanitizeForTask(event.data), event.options);
     });
   }
   

--- a/bin/testObservability/cypress/index.js
+++ b/bin/testObservability/cypress/index.js
@@ -25,12 +25,18 @@ const getCircularReplacer = () => {
   };
 };
 
+/*
+ * Returns a decycled, JSON-safe plain object, or `null` if the payload still cannot be
+ * serialized for a non-circular reason (BigInt, a throwing toJSON, a Proxy trap, etc.).
+ * `null` is a "skip this event" sentinel — callers must NOT forward it to cy.task, because
+ * the Node o11y handler expects a structured event payload, not an error stub. Skipping keeps
+ * graceful degradation total: no crash, and no malformed event reaches the collector.
+ */
 const sanitizeForTask = (data) => {
   try {
     return JSON.parse(JSON.stringify(data, getCircularReplacer()));
   } catch (e) {
-    /* Never let serialization of o11y data break the user's test run (graceful degradation). */
-    return { serializationError: e && e.message ? e.message : String(e) };
+    return null;
   }
 };
 
@@ -236,7 +242,12 @@ Cypress.on('command:enqueued', (attrs) => {
   if (args.includes('test_observability_log') || args.includes('test_observability_command')) return;
   const message = args.reduce((result, logItem) => {
     if (typeof logItem === 'object') {
-      return [result, JSON.stringify(logItem, getCircularReplacer())].join(' ');
+      /* Route through sanitizeForTask so a non-circular serialization failure can never
+       * throw out of the command:enqueued handler (same graceful-degradation contract as
+       * the flush sites). sanitizeForTask returns a decycled plain object (safe to stringify)
+       * or null; on null, contribute nothing for this item rather than crash. */
+      const safeLog = sanitizeForTask(logItem);
+      return [result, safeLog === null ? '' : JSON.stringify(safeLog)].join(' ');
     }
     return [result, logItem ? logItem.toString() : ''].join(' ');
   }, '');
@@ -337,7 +348,8 @@ beforeEach(() => {
 
   if (eventsQueue.length > 0) {
     eventsQueue.forEach(event => {
-      cy.task(event.task, sanitizeForTask(event.data), event.options);
+      const payload = sanitizeForTask(event.data);
+      if (payload !== null) cy.task(event.task, payload, event.options);
     });
   }
   eventsQueue = [];
@@ -352,7 +364,8 @@ afterEach(function() {
 
   if (eventsQueue.length > 0) {
     eventsQueue.forEach(event => {
-      cy.task(event.task, sanitizeForTask(event.data), event.options);
+      const payload = sanitizeForTask(event.data);
+      if (payload !== null) cy.task(event.task, payload, event.options);
     });
   }
   


### PR DESCRIPTION
## Problem

[SDK-6016] When BrowserStack Test Observability is enabled, the Cypress instrumentation captures command args (`command.attributes.args`) and `cy.log` items **raw** and ships them to the Node plugin via `cy.task(...)`, which JSON-serializes the payload (browser → Node). If a command/log arg is a **circular** Cypress runtime object — e.g. one whose `renderOptions.host` references itself — serialization throws:

```
Converting circular structure to JSON
    --> starting at object with constructor 't'
    |     property 'renderOptions' -> object with constructor 'Object'
    --- property 'host' closes the circle
```

…and **aborts the entire test run**. There was no try/catch around the flush, so an o11y serialization failure breaks the user's tests — contrary to the graceful-degradation contract.

This commonly surfaces in **component-testing** setups (`@cypress/vite-dev-server` / `@cypress/vue`) where mount/dev-server config objects are self-referential; e2e args are usually primitive and never trip it, which is why it stayed latent.

## Fix

- Add a WeakSet-based `getCircularReplacer()` and a `sanitizeForTask()` that decycles the payload (circular refs → `"[Circular]"`) before it is handed to `cy.task`.
- Apply it at both flush points (`beforeEach`/`afterEach`) and at the `command:enqueued` log stringify.
- `sanitizeForTask` wraps serialization in a try/catch, so o11y instrumentation can **never** break the user's test run.

Non-circular fields are preserved; only true cycles are replaced.

## Verification

- **Local (byte-faithful):** a self-referential `renderOptions.host` object throws the exact error under raw `JSON.stringify`; with `sanitizeForTask` it ships cleanly.
- **Real BrowserStack build:** a spec issuing a circular command arg (`cfg.renderOptions.host = cfg`) with `testObservability: true` completed 1/1 passed with no "Converting circular structure" in logs — build `0e384b2ee0de66beb4fe0254a85d1c66e937e02b`.

## Scope

Fix-only — single file (`bin/testObservability/cypress/index.js`), no version bump, no CHANGELOG (owned by the release PR).

## Release note

Self-referential arguments (e.g. `@cypress/vue` component-test mount / dev-server config objects) now appear as `[Circular]` in Test Observability command logs, instead of crashing the run. Non-circular fields are preserved; only the cyclic reference is replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-6016]: https://browserstack.atlassian.net/browse/SDK-6016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
