### PR TITLE
fix(ci-info): use GITHUB_RUN_ID for build_number on GitHub Actions [SDK-6279]

### DIFF
--- a/bin/helpers/helper.js
+++ b/bin/helpers/helper.js
@@ -274,7 +274,7 @@ exports.getCiInfo = () => {
       name: "GitHub Actions",
       build_url: `${env.GITHUB_SERVER_URL || 'https://github.com'}/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}`,
       job_name: env.GITHUB_WORKFLOW || env.GITHUB_JOB,
-      build_number: env.GITHUB_RUN_NUMBER
+      build_number: env.GITHUB_RUN_ID
     };
   }
   // Buildkite


### PR DESCRIPTION
## Problem

On **GitHub Actions**, `getCiInfo()` (`bin/helpers/helper.js`) populated `build_number` from `GITHUB_RUN_NUMBER` — the per-workflow **sequential counter** (e.g. `23`) — while `build_url` is built from `GITHUB_RUN_ID` — the **globally-unique run id** (`26976467840`) that appears in the `actions/runs/<id>` URL.

So the `ci_info` the SDK ships to TestHub had `build_url` and `build_number` pointing at two different identifiers for the same run. Test Observability's dashboard **Rerun** keys its GitHub `workflow_dispatch` re-dispatch off `build_number`; `23` is not a valid run id, so GitHub returns 404, which obs-api translates to `400 "Invalid Params!"`, surfacing to the customer as an HTTP 500. (SDK-6279)

## Fix

```diff
- build_number: env.GITHUB_RUN_NUMBER
+ build_number: env.GITHUB_RUN_ID
```

Aligns `build_number` with the run id `build_url` already uses on the line above.

## Scope

GitHub Actions branch only. Every other CI provider (Jenkins, CircleCI, Travis, Bitbucket, Drone, Semaphore, GitLab, Buildkite, VSTS) has its own independent `build_number` line and is untouched — GitHub was the lone provider whose `build_number` source diverged from its own `build_url` source. Introduced in `354ddffd` (INTG-2082).

## Verification

`getCiInfo()` run under env-faithful GitHub Actions variables:

| State | `build_number` | matches `build_url` `runs/<id>`? |
|---|---|---|
| Before | `"23"` | ❌ |
| After | `"26976467840"` | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)