### PR TITLE
Fix local_mode set to undefined in logs

### DIFF
--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -889,7 +889,7 @@ exports.setLocalMode = (bsConfig, args) => {
     if (localModeInferred && localModeUndefined) {
       bsConfig.connection_settings.local_mode_inferred = local_mode;
     }
-    logger.debug(`local_mode set to ${bsConfig.connection_settings.local_mode_inferred}`);
+    logger.debug(`local_mode set to ${bsConfig.connection_settings.local_mode}`);
   }
 };
 


### PR DESCRIPTION
## TL;DR

`--cli-debug` printed `local_mode set to undefined` whenever a user explicitly set `connection_settings.local_mode` in `browserstack.json`. The log was reading `local_mode_inferred`, which only gets populated on the inferred-default path. Switched the log to read `local_mode` (the resolved final value), which is guaranteed set before the log fires.

## Issue

In `bin/helpers/utils.js` → `exports.setLocalMode`, the debug log referenced the wrong property:

```js
logger.debug(`local_mode set to ${bsConfig.connection_settings.local_mode_inferred}`);
```

`local_mode_inferred` is only assigned when `localModeInferred && localModeUndefined` — i.e. only when the user did **not** supply `local_mode`. When the user explicitly sets `connection_settings.local_mode = "always-on"` (or `"on-demand"`), `localModeUndefined === false`, so the assignment is skipped and the property stays `undefined`. The log fires unconditionally → `local_mode set to undefined`.

Repro `browserstack.json`:
```json
"connection_settings": { "local": true, "local_mode": "always-on" }
```
Command: `npx browserstack-cypress run --cli-debug`
Output (broken):
```
debug: local_mode set to undefined
```

## Fix

One-line change — log `bsConfig.connection_settings.local_mode` (set just above in the same function) instead of `local_mode_inferred`:

```diff
-    logger.debug(`local_mode set to ${bsConfig.connection_settings.local_mode_inferred}`);
+    logger.debug(`local_mode set to ${bsConfig.connection_settings.local_mode}`);
```

### Verification matrix

Reproduced via a dummy cypress project against 3 `connection_settings` shapes.

| Case | `connection_settings` | Before (broken) | After (fixed) |
|---|---|---|---|
| Explicit always-on | `{local:true, local_mode:"always-on"}` | `local_mode set to undefined` ❌ | `local_mode set to always-on` ✅ |
| Explicit on-demand | `{local:true, local_mode:"on-demand"}` | `local_mode set to undefined` ❌ | `local_mode set to on-demand` ✅ |
| Default inferred   | `{local:true}`                          | `local_mode set to on-demand` ✅ | `local_mode set to on-demand` ✅ |

## Files changed

| File | Change |
|---|---|
| `bin/helpers/utils.js` | Replaced `bsConfig.connection_settings.local_mode_inferred` with `bsConfig.connection_settings.local_mode` in the debug log inside `exports.setLocalMode`. |
