### PR TITLE
chore(release): bump version to 1.36.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.36.8",
+  "version": "1.36.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-cypress-cli",
-  "version": "1.36.8",
+  "version": "1.36.9",
   "description": "BrowserStack Cypress CLI for Cypress integration with BrowserStack's remote devices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What is this about?

Version bump `1.36.8` → `1.36.9` in `package.json` + `package-lock.json` only (via `npm version patch`).

**Context:** `browserstack-cypress-cli@1.36.9` is already live on npm — the [CypressCliNpmPackagePublish build #8](https://minion.browserstack.com/job/AutomateOnboardingPackages/job/CypressCliNpmPackagePublish/8/) published it (2026-06-10 13:28 IST) but its `git push` was denied (`deploybs-com` had read-only access at the time), so the version-bump commit, `v1.36.9` tag, and GitHub release never landed. This PR aligns master with the published npm version; the tag + release will be created on the merge commit.

Contains released changes:
- #1117 — fix(observability): TRA build duration counted post-test CLI work
- #1118 — fix(observability): circular `cy.task` payload crash

## Related Jira task/s

- [SDK-5978](https://browserstack.atlassian.net/browse/SDK-5978)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-5978]: https://browserstack.atlassian.net/browse/SDK-5978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ