### PR TITLE
fix(observability): honour configured build_name over BROWSERSTACK_BUILD_NAME on new dashboard [SDK-6431]

### DIFF
--- a/bin/helpers/helper.js
+++ b/bin/helpers/helper.js
@@ -307,11 +307,7 @@ exports.getBuildDetails = (bsConfig, isO11y = false) => {
       buildDescription = '',
       buildTags = [];
 
-  /* Pick from environment variables */
-  buildName = process.env.BROWSERSTACK_BUILD_NAME || buildName;
-  projectName = process.env.BROWSERSTACK_PROJECT_NAME || projectName;
-
-  /* Pick from testObservabilityOptions */
+  /* Pick from testObservabilityOptions (explicit config takes precedence) */
   if(isTestObservabilityOptionsPresent) {
     buildName = buildName || bsConfig["testObservabilityOptions"]["buildName"];
     projectName = projectName || bsConfig["testObservabilityOptions"]["projectName"];
@@ -319,10 +315,16 @@ exports.getBuildDetails = (bsConfig, isO11y = false) => {
     buildDescription = buildDescription || bsConfig["testObservabilityOptions"]["buildDescription"];
   }
 
-  /* Pick from run settings */
+  /* Pick from run settings (explicit config) */
   buildName = buildName || bsConfig["run_settings"]["build_name"];
   projectName = projectName || bsConfig["run_settings"]["project_name"];
   if(!utils.isUndefined(bsConfig["run_settings"]["build_tag"])) buildTags = [...buildTags, bsConfig["run_settings"]["build_tag"]];
+
+  /* Fall back to environment variables only when not explicitly configured.
+     Keeps the new dashboard (TestHub) consistent with the Automate capability
+     path, which honours run_settings.build_name over CI-derived env vars. [SDK-6431] */
+  buildName = buildName || process.env.BROWSERSTACK_BUILD_NAME;
+  projectName = projectName || process.env.BROWSERSTACK_PROJECT_NAME;
 
   buildName = buildName || path.basename(path.resolve(process.cwd()));
 

--- a/test/unit/bin/helpers/helper.js
+++ b/test/unit/bin/helpers/helper.js
@@ -38,4 +38,48 @@ describe('helper', () => {
       expect(helper.getSizeOfJsonObjectInBytes(truncatedVCSInfo)).to.be.lessThanOrEqual(64 * 1024);
     });
   });
+
+  describe('getBuildDetails', () => {
+    let originalBuildNameEnv, originalProjectNameEnv;
+
+    beforeEach(() => {
+      originalBuildNameEnv = process.env.BROWSERSTACK_BUILD_NAME;
+      originalProjectNameEnv = process.env.BROWSERSTACK_PROJECT_NAME;
+      delete process.env.BROWSERSTACK_BUILD_NAME;
+      delete process.env.BROWSERSTACK_PROJECT_NAME;
+    });
+
+    afterEach(() => {
+      if (originalBuildNameEnv === undefined) delete process.env.BROWSERSTACK_BUILD_NAME;
+      else process.env.BROWSERSTACK_BUILD_NAME = originalBuildNameEnv;
+      if (originalProjectNameEnv === undefined) delete process.env.BROWSERSTACK_PROJECT_NAME;
+      else process.env.BROWSERSTACK_PROJECT_NAME = originalProjectNameEnv;
+    });
+
+    // SDK-6431: explicit build_name from config must win over CI-derived
+    // BROWSERSTACK_BUILD_NAME so the new dashboard (TestHub) matches Automate.
+    it('prefers run_settings.build_name over BROWSERSTACK_BUILD_NAME env var', () => {
+      process.env.BROWSERSTACK_BUILD_NAME = 'Bamboo-42#10';
+      const bsConfig = { run_settings: { build_name: 'sanity' }, testObservabilityOptions: {} };
+      expect(helper.getBuildDetails(bsConfig, true).buildName).to.eq('sanity');
+    });
+
+    it('prefers testObservabilityOptions.buildName over the env var', () => {
+      process.env.BROWSERSTACK_BUILD_NAME = 'Bamboo-42#10';
+      const bsConfig = { run_settings: { build_name: 'sanity' }, testObservabilityOptions: { buildName: 'obs-build' } };
+      expect(helper.getBuildDetails(bsConfig, true).buildName).to.eq('obs-build');
+    });
+
+    it('falls back to BROWSERSTACK_BUILD_NAME env var when no build_name is configured', () => {
+      process.env.BROWSERSTACK_BUILD_NAME = 'ci-build-99';
+      const bsConfig = { run_settings: {}, testObservabilityOptions: {} };
+      expect(helper.getBuildDetails(bsConfig, true).buildName).to.eq('ci-build-99');
+    });
+
+    it('prefers run_settings.project_name over BROWSERSTACK_PROJECT_NAME env var', () => {
+      process.env.BROWSERSTACK_PROJECT_NAME = 'ci-project';
+      const bsConfig = { run_settings: { project_name: 'my-project' }, testObservabilityOptions: {} };
+      expect(helper.getBuildDetails(bsConfig, true).projectName).to.eq('my-project');
+    });
+  });
 });


### PR DESCRIPTION
## What & why

[SDK-6431] On CI (reported on Atlassian Bamboo), the **new TestHub/TRA-backed dashboard** showed a CI-derived build name (e.g. `Bamboo-42`) instead of the `build_name: "sanity"` configured in `browserstack.json`, while the **old Automate dashboard** correctly showed the configured value.

### Root cause
`getBuildDetails()` (`bin/helpers/helper.js`) put `process.env.BROWSERSTACK_BUILD_NAME` at the **top** of its precedence chain, above explicit config:

```
BROWSERSTACK_BUILD_NAME (env) -> testObservabilityOptions.buildName -> run_settings.build_name -> cwd
```

The Automate capability path (`capabilityHelper.js`) uses only `run_settings.build_name` and never reads the env var. When the customer's CI exposes `BROWSERSTACK_BUILD_NAME`, the two dashboards disagree. The build name in the TRA build-creation request body (`testhubHandler.js` `name: buildName`) is built from `getBuildDetails`, so it carried the CI value.

Confirmed against the customer's reported TRA payload (`{"request_body":{"name":"Bamboo-42",...}}`) and SDK 1.36.8 (identical precedence).

### Fix
Demote `BROWSERSTACK_BUILD_NAME` / `BROWSERSTACK_PROJECT_NAME` to a **fallback** so explicit config wins. New precedence:

```
testObservabilityOptions.buildName -> run_settings.build_name -> env var -> cwd
```

Makes the new dashboard consistent with Automate and preserves the env var for users who don't configure a build name (no regression).

## Tests
- 4 new unit tests in `test/unit/bin/helpers/helper.js`: config beats env, testObs.buildName beats env, env fallback when unconfigured, project_name precedence.
- `npx mocha test/unit/bin/helpers/helper.js` -> 7 passing.

## Note
Precedence/behaviour change (explicit config now beats `BROWSERSTACK_BUILD_NAME` on the new dashboard). Intentional for cross-dashboard consistency — flagging for reviewer awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SDK-6431]: https://browserstack.atlassian.net/browse/SDK-6431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ