### PR TITLE
fix(observability): BuildUpdate one-shot guard — flip haveSentBuildUpdate [SDK-6574]

### DIFF
--- a/bin/testObservability/reporter/index.js
+++ b/bin/testObservability/reporter/index.js
@@ -577,6 +577,7 @@ class MyReporter {
           }
         };
         await uploadEventData(buildUpdateData);
+        this.haveSentBuildUpdate = true;
       }
 
       // Add started hooks to the hash


### PR DESCRIPTION
## What is this about?

The Observability reporter is designed to send `BuildUpdate` **once**, but the one-shot guard never flipped its flag. In `bin/testObservability/reporter/index.js`, the guard is `if(!this.haveSentBuildUpdate && ...)`, but `this.haveSentBuildUpdate` was never set to `true` after the event was sent. So it stayed `false` and `BuildUpdate` re-fired on **every test/hook event** — hundreds to thousands of byte-identical `observability_version` payloads per build (≥10k observed for a single Cypress tenant in prod; 13/13 top BuildUpdate emitters are Cypress across SDK 1.31–1.36.x).

The payload (`observability_version`) is a build-level constant, so every re-emit is redundant. This floods the TRA `event_batch_top_v2` Kafka partition (build-uuid-keyed → hot partition) and drives redundant testhub round-trips.

**Fix (additive, one line):** set `this.haveSentBuildUpdate = true` immediately after the BuildUpdate is sent. `BuildUpdate` now fires once per reporter instance (≈ once per spec process); the byte-identical per-process emits are collapsed to one per build by the consumer-side dedupe in TRAP-4033.

> Note: the guard has never worked since it was introduced (commit `a0f7404`, 2023-06-18) — it is not a recent regression.

## Change

```diff
         await uploadEventData(buildUpdateData);
+        this.haveSentBuildUpdate = true;
       }
```

## Related Jira task/s
- https://browserstack.atlassian.net/browse/SDK-6574
- Relates: https://browserstack.atlassian.net/browse/TRAP-4033 (consumer-side once-per-build dedupe — the durable backstop for version-pinned customers; complementary to this source fix)

## Testing
Single-line change; validated locally (no test file added to keep the PR minimal):
- **Reproduce → resolve:** a throwaway proxyquire/sinon harness driving 5 test events through one reporter instance emits **5** `BuildUpdate` without this line and **exactly 1** with it.
- **No regressions:** full `npm test` suite is unchanged at **678 passing / 13 failing** (the 13 are pre-existing failures in unrelated modules — errorReporting / zipUpload / results-table / video-config).
