### PR TITLE
OB-10135: propagate automate build id on observability buildStop

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -340,6 +340,11 @@ module.exports = function run(args, rawArgs) {
                 utils.setProcessHooks(data.build_id, bsConfig, bs_local, args, buildReportData);
                 if(isTestObservabilitySession) {
                   utils.setO11yProcessHooks(data.build_id, bsConfig, bs_local, args, buildReportData);
+                  // OB-10135: cache the automate build id so `stopBuildUpstream`
+                  // can include it on the obs-api buildStop payload. Enables the
+                  // synergy dashboard to call the railsApp resource-errors
+                  // endpoint in the automate id-space directly.
+                  process.env.BROWSERSTACK_AUTOMATION_BUILD_ID = data.build_id;
                 }
                 let message = `${data.message}! ${Constants.userMessages.BUILD_CREATED} with build id: ${data.build_id}`;
                 let dashboardLink = `${Constants.userMessages.VISIT_DASHBOARD} ${data.dashboard_url}`;

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -340,10 +340,7 @@ module.exports = function run(args, rawArgs) {
                 utils.setProcessHooks(data.build_id, bsConfig, bs_local, args, buildReportData);
                 if(isTestObservabilitySession) {
                   utils.setO11yProcessHooks(data.build_id, bsConfig, bs_local, args, buildReportData);
-                  // OB-10135: cache the automate build id so `stopBuildUpstream`
-                  // can include it on the obs-api buildStop payload. Enables the
-                  // synergy dashboard to call the railsApp resource-errors
-                  // endpoint in the automate id-space directly.
+                  // OB-10135: read by stopBuildUpstream in testObservability/helper/helper.js
                   process.env.BROWSERSTACK_AUTOMATION_BUILD_ID = data.build_id;
                 }
                 let message = `${data.message}! ${Constants.userMessages.BUILD_CREATED} with build id: ${data.build_id}`;

--- a/bin/testObservability/helper/helper.js
+++ b/bin/testObservability/helper/helper.js
@@ -685,10 +685,7 @@ exports.stopBuildUpstream = async () => {
     } else {
       const data = {
         'stop_time': (new Date()).toISOString(),
-        // OB-10135: propagate the automate build hashed_id (cached at
-        // build-create time in runs.js) so obs-api can persist it and the
-        // synergy dashboard can call the railsApp resource-errors endpoint
-        // in the automate id-space directly.
+        // OB-10135: cached in bin/commands/runs.js at build-create
         'automate_build_id': process.env.BROWSERSTACK_AUTOMATION_BUILD_ID
       };
       const config = {

--- a/bin/testObservability/helper/helper.js
+++ b/bin/testObservability/helper/helper.js
@@ -684,7 +684,12 @@ exports.stopBuildUpstream = async () => {
       };
     } else {
       const data = {
-        'stop_time': (new Date()).toISOString()
+        'stop_time': (new Date()).toISOString(),
+        // OB-10135: propagate the automate build hashed_id (cached at
+        // build-create time in runs.js) so obs-api can persist it and the
+        // synergy dashboard can call the railsApp resource-errors endpoint
+        // in the automate id-space directly.
+        'automate_build_id': process.env.BROWSERSTACK_AUTOMATION_BUILD_ID
       };
       const config = {
         headers: {


### PR DESCRIPTION
## Summary

Stamp the **automate build id** onto the observability `buildStop` payload so the pipeline can persist it and the synergy dashboard can address the automate resource-errors endpoint directly (OB-10135). Producer-side change only — two lines, no new endpoint.

## What lands here

| File | Change |
|---|---|
| `bin/commands/runs.js` | On automate build-create success (o11y session), cache the id: `process.env.BROWSERSTACK_AUTOMATION_BUILD_ID = data.build_id;` |
| `bin/testObservability/helper/helper.js` | Include `automate_build_id: process.env.BROWSERSTACK_AUTOMATION_BUILD_ID` in the `PUT /api/v1/builds/:id/stop` payload |

The env var mirrors the existing `BS_TESTOPS_BUILD_HASHED_ID` pattern. The automate build is created **after** the observability buildStart (post zip-upload), so `buildStop` is the first lifecycle event where the id exists — hence it's stamped there, not at start.

## Why

OB-9830 traced the Cypress resource-errors 404 to an id-space mismatch on the synergy dashboard. The clean end-state: the SDK sends the automate build id → pipeline persists it in the build metadata → obs-api serves it → FE calls the automate resource-errors endpoint with the correct id. This PR is the producer half.

## Related PRs
- **Pipeline (persistence):** browserstack/observability-pipeline#7343
- **Frontend (consumer):** browserstack/frontend#48305

## Test plan
- [x] Real Cypress smoke via the patched CLI against preprod — the buildStop payload carries `automate_build_id`, and the value surfaces on the observability build's `metaData` and rides the `BUILD_FINISHED` pusher event (confirmed on the synergy dashboard).

## Notes
- Backward compatible: the field is nullable; older/other-framework runs are unaffected.
- No detection gating — the id is stamped whenever the automate build id is present.
