### PR TITLE
[A11Y-12376] Env-driven collector URL for lower envs (BSTACK_ENV)

### DIFF
--- a/bin/testObservability/helper/constants.js
+++ b/bin/testObservability/helper/constants.js
@@ -3,10 +3,12 @@ const path = require('path');
 exports.consoleHolder = Object.assign({},console);
 exports.BATCH_SIZE = 1000;
 exports.BATCH_INTERVAL = 2000;
+// Lower-env collector is collector-testhub-<env> (per a11y/sdk/scripts/setupOnDemandSDKRepo.sh),
+// NOT collector-observability-<env> (that host does not exist).
 const _env = process.env.BSTACK_ENV;
 const _host = (!_env || _env === 'prod')
   ? 'collector-observability.browserstack.com'
-  : `collector-observability-${_env}.bsstag.com`;
+  : `collector-testhub-${_env}.bsstag.com`;
 exports.API_URL = `https://${_host}`;
 
 exports.IPC_EVENTS = {

--- a/bin/testObservability/helper/constants.js
+++ b/bin/testObservability/helper/constants.js
@@ -3,7 +3,11 @@ const path = require('path');
 exports.consoleHolder = Object.assign({},console);
 exports.BATCH_SIZE = 1000;
 exports.BATCH_INTERVAL = 2000;
-exports.API_URL = 'https://collector-observability.browserstack.com';
+const _env = process.env.BSTACK_ENV;
+const _host = (!_env || _env === 'prod')
+  ? 'collector-observability.browserstack.com'
+  : `collector-observability-${_env}.bsstag.com`;
+exports.API_URL = `https://${_host}`;
 
 exports.IPC_EVENTS = {
   LOG: 'testObservability:cypressLog',

--- a/test/unit/bin/testObservability/collectorUrl.test.js
+++ b/test/unit/bin/testObservability/collectorUrl.test.js
@@ -5,9 +5,9 @@ describe('o11y collector URL', () => {
     const c = require('../../../../bin/testObservability/helper/constants');
     expect(c.API_URL).to.equal('https://collector-observability.browserstack.com');
   });
-  it('expands for lower env', () => {
+  it('expands for lower env to collector-testhub', () => {
     process.env.BSTACK_ENV = 'k8s';
     const c = require('../../../../bin/testObservability/helper/constants');
-    expect(c.API_URL).to.equal('https://collector-observability-k8s.bsstag.com');
+    expect(c.API_URL).to.equal('https://collector-testhub-k8s.bsstag.com');
   });
 });

--- a/test/unit/bin/testObservability/collectorUrl.test.js
+++ b/test/unit/bin/testObservability/collectorUrl.test.js
@@ -1,0 +1,13 @@
+const { expect } = require('chai');
+describe('o11y collector URL', () => {
+  afterEach(() => { delete process.env.BSTACK_ENV; delete require.cache[require.resolve('../../../../bin/testObservability/helper/constants')]; });
+  it('defaults to prod', () => {
+    const c = require('../../../../bin/testObservability/helper/constants');
+    expect(c.API_URL).to.equal('https://collector-observability.browserstack.com');
+  });
+  it('expands for lower env', () => {
+    process.env.BSTACK_ENV = 'k8s';
+    const c = require('../../../../bin/testObservability/helper/constants');
+    expect(c.API_URL).to.equal('https://collector-observability-k8s.bsstag.com');
+  });
+});


### PR DESCRIPTION
Gates cypress-cli lower-env endpoints behind BSTACK_ENV and points the collector host at collector-testhub-<env>.bsstag.com. Unset/prod = published prod behavior. Consumed by a11y/sdk_e2e cypress framework. Ref A11Y-12376.