### PR TITLE
fix(ci-info): detect GitHub Actions before presence-only CI providers [SDK-7081]

### DIFF
--- a/bin/helpers/helper.js
+++ b/bin/helpers/helper.js
@@ -102,7 +102,7 @@ exports.getGitMetaData = () => {
       if(!info.commonGitDir) {
         logger.debug(`Unable to find a Git directory`);
         exports.debug(`Unable to find a Git directory`);
-        resolve({});
+        return resolve({});
       }
       if(!info.author && exports.findGitConfig(process.cwd())) {
         /* commit objects are packed */
@@ -196,6 +196,16 @@ exports.getHostInfo = () => {
 exports.getCiInfo = () => {
   var env = process.env;
 
+  // GitHub Actions — checked before the presence-only providers (Jenkins,
+  // Bitbucket) so leftover env vars on self-hosted runners can't shadow it
+  if (env.GITHUB_ACTIONS === "true" || (env.CI === "true" && env.GITHUB_RUN_ID)) {
+    return {
+      name: "GitHub Actions",
+      build_url: `${env.GITHUB_SERVER_URL || 'https://github.com'}/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}`,
+      job_name: env.GITHUB_WORKFLOW || env.GITHUB_JOB,
+      build_number: env.GITHUB_RUN_ID
+    };
+  }
   // Jenkins
   if ((typeof env.JENKINS_URL === "string" && env.JENKINS_URL.length > 0) || (typeof env.JENKINS_HOME === "string" && env.JENKINS_HOME.length > 0)) {
     return {
@@ -266,15 +276,6 @@ exports.getCiInfo = () => {
       build_url: env.CI_JOB_URL,
       job_name: env.CI_JOB_NAME,
       build_number: env.CI_JOB_ID
-    };
-  }
-  // GitHub Actions
-  if (env.GITHUB_ACTIONS === "true" || env.CI === "true" && env.GITHUB_RUN_ID) {
-    return {
-      name: "GitHub Actions",
-      build_url: `${env.GITHUB_SERVER_URL || 'https://github.com'}/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}`,
-      job_name: env.GITHUB_WORKFLOW || env.GITHUB_JOB,
-      build_number: env.GITHUB_RUN_ID
     };
   }
   // Buildkite

--- a/test/unit/bin/helpers/helper.js
+++ b/test/unit/bin/helpers/helper.js
@@ -38,4 +38,63 @@ describe('helper', () => {
       expect(helper.getSizeOfJsonObjectInBytes(truncatedVCSInfo)).to.be.lessThanOrEqual(64 * 1024);
     });
   });
+
+  describe('getCiInfo', () => {
+    const CI_VARS = ['CI', 'GITHUB_ACTIONS', 'GITHUB_SERVER_URL', 'GITHUB_REPOSITORY', 'GITHUB_RUN_ID', 'GITHUB_RUN_NUMBER', 'GITHUB_WORKFLOW', 'GITHUB_JOB', 'JENKINS_URL', 'JENKINS_HOME', 'BUILD_URL', 'JOB_NAME', 'BUILD_NUMBER'];
+    let savedEnv = {};
+
+    beforeEach(() => {
+      CI_VARS.forEach((k) => {
+        savedEnv[k] = process.env[k];
+        delete process.env[k];
+      });
+    });
+
+    afterEach(() => {
+      CI_VARS.forEach((k) => {
+        if (savedEnv[k] === undefined) delete process.env[k];
+        else process.env[k] = savedEnv[k];
+      });
+      savedEnv = {};
+    });
+
+    const setGithubActionsEnv = () => {
+      process.env.CI = 'true';
+      process.env.GITHUB_ACTIONS = 'true';
+      process.env.GITHUB_SERVER_URL = 'https://github.com';
+      process.env.GITHUB_REPOSITORY = 'org/repo';
+      process.env.GITHUB_RUN_ID = '27412345678';
+      process.env.GITHUB_WORKFLOW = 'CI Workflow';
+    };
+
+    it('detects GitHub Actions with build_url and run-id build_number', () => {
+      setGithubActionsEnv();
+      const ciInfo = helper.getCiInfo();
+      expect(ciInfo.name).to.eq('GitHub Actions');
+      expect(ciInfo.build_url).to.eq('https://github.com/org/repo/actions/runs/27412345678');
+      expect(ciInfo.build_number).to.eq('27412345678');
+    });
+
+    it('prefers GitHub Actions over leaked Jenkins env vars on self-hosted runners', () => {
+      setGithubActionsEnv();
+      process.env.JENKINS_HOME = '/var/lib/jenkins';
+      const ciInfo = helper.getCiInfo();
+      expect(ciInfo.name).to.eq('GitHub Actions');
+      expect(ciInfo.build_url).to.eq('https://github.com/org/repo/actions/runs/27412345678');
+    });
+
+    it('detects Jenkins when no explicit CI marker is set', () => {
+      process.env.JENKINS_URL = 'https://ci.internal/job/x';
+      process.env.BUILD_URL = 'https://ci.internal/job/x/42/';
+      process.env.JOB_NAME = 'x';
+      process.env.BUILD_NUMBER = '42';
+      const ciInfo = helper.getCiInfo();
+      expect(ciInfo.name).to.eq('Jenkins');
+      expect(ciInfo.build_url).to.eq('https://ci.internal/job/x/42/');
+    });
+
+    it('returns null when no CI is detected', () => {
+      expect(helper.getCiInfo()).to.be.null;
+    });
+  });
 });


### PR DESCRIPTION
## Problem

[SDK-7081](https://browserstack.atlassian.net/browse/SDK-7081) — TRA's Re-run control is missing on some of a customer's Cypress builds. obs-api computes the `reRun` flag per build and **force-disables it when the build has no CI `build_url`**; the TRA frontend greys the control off that flag.

In `getCiInfo()` (`bin/helpers/helper.js`) the **Jenkins** check runs first and matches on the mere *presence* of `JENKINS_URL`/`JENKINS_HOME`. On a **self-hosted GitHub Actions runner** with leftover Jenkins env vars (the customer runs `runs-on: [self-hosted, ...]`), the build is classified as Jenkins:

```json
{"name": "Jenkins"}
```

`build_url`/`job_name`/`build_number` are all `undefined` (Jenkins vars like `BUILD_URL` aren't set), so the serialized `ci_info` reaches TestHub without a `build_url` → re-run permanently greyed for that build — even on the latest CLI.

Note: the customer's currently-affected workflows also pin pre-1.36.5 CLI versions (no GHA detection at all → `ci_info: null`, same gate). That part is resolved by upgrading the pins to ≥ 1.36.10; this PR closes the remaining variant that can hit current versions.

## Fix

Move the GitHub Actions branch — keyed on the explicit `GITHUB_ACTIONS === "true"` marker — ahead of the presence-only providers. Explicit CI markers now win over incidental env leftovers.

Also: `getGitMetaData()` now `return`s after `resolve({})` when no git directory is found, instead of falling through and attempting a second resolve.

## Scope

Detection *order* only — every provider's returned fields are unchanged. Pure-Jenkins environments (no `GITHUB_ACTIONS`/`GITHUB_RUN_ID`) still resolve to Jenkins. Complements #1123 (SDK-6279), which fixed `build_number` in the same branch.

## Verification

`getCiInfo()` under env-faithful GitHub Actions vars **plus** a leaked `JENKINS_HOME=/var/lib/jenkins`:

| State | Result |
|---|---|
| Before | `{"name":"Jenkins"}` — no `build_url` → re-run greyed |
| After | `{"name":"GitHub Actions","build_url":".../actions/runs/27412345678","build_number":"27412345678"}` |

- New unit tests in `test/unit/bin/helpers/helper.js`: GHA detection, the Jenkins-shadowing regression, pure Jenkins, no-CI — all pass.
- Full suite: 693 passing / 16 failing — the 16 failures are pre-existing on `master` (verified identical with the change stashed).
- End-to-end repro of the gate on real builds (identical suite + GHA env, only CLI version differs): TRA build `xa9qkg059unqm0s76mshuadvsiphhdcfbqdafurc` (`ci_info: null`, CLI 1.36.3) vs `jl1fvypsbnpeq01viexykee0fdfnxlcye4kuctk3` (`ci_info` populated, CLI 1.36.13), confirmed via `GET /ext/v1/builds/<uuid>`.

## Release

- [ ] minor
- [x] patch

**Release notes:** Fixed CI detection so GitHub Actions builds on self-hosted runners with leftover Jenkins environment variables are correctly reported as GitHub Actions, restoring Test Observability's Re-run option for those builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-7081]: https://browserstack.atlassian.net/browse/SDK-7081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ