### PR TITLE
fix(rerun): honour BROWSERSTACK_RERUN_TESTS so only failed specs re-run [SDK-7124]

### DIFF
--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -495,7 +495,10 @@ exports.setNodeVersion = (bsConfig, args) => {
 // command line args takes precedence over config
 exports.setUserSpecs = (bsConfig, args) => {
   if(o11yHelpers.isBrowserstackInfra() && o11yHelpers.isTestObservabilitySession() && o11yHelpers.shouldReRunObservabilityTests()) {
-    bsConfig.run_settings.specs = process.env.BROWSERSTACK_RERUN_TESTS;
+    // BROWSERSTACK_RERUN_TESTS arrives comma+space separated (e.g. "a.ts, b.ts"); normalise
+    // like the other spec sources below, else sanitizeSpecsPattern builds "{a.ts, b.ts}" whose
+    // space-prefixed brace alternatives never match and the failed-spec filter collapses.
+    bsConfig.run_settings.specs = this.fixCommaSeparatedString(process.env.BROWSERSTACK_RERUN_TESTS);
     return;
   }
 

--- a/bin/testObservability/helper/helper.js
+++ b/bin/testObservability/helper/helper.js
@@ -879,7 +879,10 @@ const getReRunSpecs = (rawArgs) => {
       }
     }
     if(startIdx != -1) rawArgs.splice(startIdx, numEle + 1);
-    finalArgs = [...rawArgs, '--spec', process.env.BROWSERSTACK_RERUN_TESTS];
+    // Normalise the comma+space separated rerun list ("a.ts, b.ts") to comma-only before
+    // handing it to cypress --spec; a leading space makes cypress miss every spec but the first.
+    const reRunSpecs = process.env.BROWSERSTACK_RERUN_TESTS.split(",").map(spec => spec.trim()).filter(Boolean).join(",");
+    finalArgs = [...rawArgs, '--spec', reRunSpecs];
   }
   return finalArgs.filter(item => item !== '--disable-test-observability' && item !== '--disable-browserstack-automation');
 }

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -699,6 +699,33 @@ describe('utils', () => {
       expect(bsConfig.run_settings.specs).to.be.eq('spec1,spec2');
     });
 
+    context('when re-running observability failed tests (BROWSERSTACK_RERUN_TESTS)', () => {
+      let rerunStubs = [];
+      beforeEach(() => {
+        rerunStubs.push(sinon.stub(o11yHelpers, 'isBrowserstackInfra').returns(true));
+        rerunStubs.push(sinon.stub(o11yHelpers, 'isTestObservabilitySession').returns(true));
+        rerunStubs.push(sinon.stub(o11yHelpers, 'shouldReRunObservabilityTests').returns(true));
+      });
+      afterEach(() => {
+        rerunStubs.forEach((s) => s.restore());
+        rerunStubs = [];
+        delete process.env.BROWSERSTACK_RERUN_TESTS;
+      });
+
+      it('normalises the comma+space separated rerun spec list to comma-only (SDK-7124)', () => {
+        process.env.BROWSERSTACK_RERUN_TESTS =
+          'FO-E2E-05.ts, FO-E2E-02.ts, FO-E2E-06.ts, FO-E2E-07.ts, FO-E2E-03.ts';
+        let bsConfig = { run_settings: { specs: ['some/other/spec.js'] } };
+
+        utils.setUserSpecs(bsConfig, { specs: null });
+
+        expect(bsConfig.run_settings.specs).to.be.eq(
+          'FO-E2E-05.ts,FO-E2E-02.ts,FO-E2E-06.ts,FO-E2E-07.ts,FO-E2E-03.ts'
+        );
+        expect(bsConfig.run_settings.specs).to.not.contain(' ');
+      });
+    });
+
     it('does not set the specs list if no specs key specified', () => {
       let bsConfig = {
         run_settings: {},


### PR DESCRIPTION
## Summary

TRA dashboard **Re-run → failed tests only** was re-running the *whole* Cypress suite for EasyJet (browserstack-cypress-cli 1.36.13, GitHub Actions). Root cause is a spec-list **format bug in the CLI**: obs-api passes the failed specs comma+**space** separated (`BROWSERSTACK_RERUN_TESTS="a.ts, b.ts"`), but the re-run code path fed that raw string into the spec glob without stripping the spaces — so the glob never matched the intended specs and the run fell back to the full suite.

## What lands here

| File | Change |
|---|---|
| `bin/helpers/utils.js` | `setUserSpecs` — route `BROWSERSTACK_RERUN_TESTS` through `fixCommaSeparatedString` (the same normalisation every other spec source already gets) before assigning `run_settings.specs`. |
| `bin/testObservability/helper/helper.js` | `getReRunSpecs` (local `cypress run` path) — trim each entry of the rerun list before passing to `cypress --spec`, where a leading space silently drops every spec but the first. |
| `test/unit/bin/helpers/utils.js` | Regression test on the rerun branch of `setUserSpecs` using the ticket's exact 5-spec value. |

## Why the whole suite ran

`sanitizeSpecsPattern` wraps a multi-comma spec string in braces for glob. With the raw value it produced:

```
"{FO-E2E-05.ts, FO-E2E-02.ts, FO-E2E-06.ts, FO-E2E-07.ts, FO-E2E-03.ts}"
```

Brace alternatives keep the leading space (`" FO-E2E-02.ts"`), so only the first (space-free) alternative can match. Locally the glob resolves **1/5**; on BrowserStack the malformed pattern resolves to nothing and the runner falls back to the full suite — the "every spec re-ran" symptom in the ticket (child build 141199119 ran all 9 specs, incl. 4 never in the payload).

After normalisation the pattern is `{FO-E2E-05.ts,FO-E2E-02.ts,...}` and resolves to exactly the 5 failed specs.

## Test plan

- [x] New regression unit test (`setUserSpecs` … `SDK-7124`) — **fails** on the pre-fix line (asserts the space-mangled string), **passes** after the fix.
- [x] Full `test/unit/bin/helpers/utils.js` suite: **391 passing** (was 390) — the +1 is this test; the 5 failing (`setLocalArgs`/`setNodeVersion`/`getVideoConfig`) are pre-existing and unrelated (present on a clean `master` checkout too).
- [x] Standalone reproduction against a 9-spec fixture with the ticket's exact env value, using real `glob@7` + the verbatim `sanitizeSpecsPattern`/`fixCommaSeparatedString`: pre-fix matches 1/9, post-fix matches exactly the 5 failed specs.

## Notes / scope

- Backward compatible: `fixCommaSeparatedString` is a no-op on already-clean lists; non-rerun runs are unaffected.
- This fixes the **CLI-side** handling. If the failed-spec env never reaches the runner in a given CI setup (e.g. a GitHub *native* workflow re-run that replays without env injection), that is a separate Integrations/obs-api delivery concern outside this repo — this change ensures the CLI does the right thing whenever the list *is* present.

## Release

- [x] patch — bug fix only.

Fixes SDK-7124.