### PR TITLE
fix(observability): inject TRA support-file listener synchronously (SDK-7121)

### DIFF
--- a/bin/accessibility-automation/helper.js
+++ b/bin/accessibility-automation/helper.js
@@ -378,32 +378,29 @@ exports.setAccessibilityEventListeners = (bsConfig) => {
     }
     
     const globPattern = process.cwd() + supportFilesData.supportFile;
-    glob(globPattern, {}, (err, files) => {
-      if(err) {
-        logger.debug('EXCEPTION IN BUILD START EVENT : Unable to parse cypress support files');
-        return;
-      }
-      
-      files.forEach(file => {
-        try {
-          const fileName = path.basename(file);
-          if(['e2e.js', 'e2e.ts', 'component.ts', 'component.js'].includes(fileName) && !file.includes('node_modules')) {
-        
-            const defaultFileContent = fs.readFileSync(file, {encoding: 'utf-8'});
-            let cypressCommandEventListener = getAccessibilityCypressCommandEventListener(path.extname(file));
-            if(!defaultFileContent.includes(cypressCommandEventListener)) {
-              let newFileContent = defaultFileContent + 
-                                  '\n' +
-                                  cypressCommandEventListener +
-                                  '\n';
-              fs.writeFileSync(file, newFileContent, {encoding: 'utf-8'});
-              supportFileContentMap[file] = supportFilesData.cleanupParams ? supportFilesData.cleanupParams : defaultFileContent;
-            }
+    // Synchronous for the same reason as testObservability setEventListeners
+    // (SDK-7121): the caller archives the suite right after this returns, so an
+    // async glob callback would race the archive and ship un-instrumented specs.
+    const files = glob.sync(globPattern, {});
+    files.forEach(file => {
+      try {
+        const fileName = path.basename(file);
+        if(['e2e.js', 'e2e.ts', 'component.ts', 'component.js'].includes(fileName) && !file.includes('node_modules')) {
+
+          const defaultFileContent = fs.readFileSync(file, {encoding: 'utf-8'});
+          let cypressCommandEventListener = getAccessibilityCypressCommandEventListener(path.extname(file));
+          if(!defaultFileContent.includes(cypressCommandEventListener)) {
+            let newFileContent = defaultFileContent +
+                                '\n' +
+                                cypressCommandEventListener +
+                                '\n';
+            fs.writeFileSync(file, newFileContent, {encoding: 'utf-8'});
+            supportFileContentMap[file] = supportFilesData.cleanupParams ? supportFilesData.cleanupParams : defaultFileContent;
           }
-        } catch(e) {
-          logger.debug(`Unable to modify file contents for ${file} to set event listeners with error ${e}`, true, e);
         }
-      });
+      } catch(e) {
+        logger.debug(`Unable to modify file contents for ${file} to set event listeners with error ${e}`, true, e);
+      }
     });
   } catch(e) {
     logger.debug(`Unable to parse support files to set event listeners with error ${e}`, true, e);

--- a/bin/accessibility-automation/helper.js
+++ b/bin/accessibility-automation/helper.js
@@ -381,7 +381,13 @@ exports.setAccessibilityEventListeners = (bsConfig) => {
     // Synchronous for the same reason as testObservability setEventListeners
     // (SDK-7121): the caller archives the suite right after this returns, so an
     // async glob callback would race the archive and ship un-instrumented specs.
-    const files = glob.sync(globPattern, {});
+    let files;
+    try {
+      files = glob.sync(globPattern, {});
+    } catch(err) {
+      logger.debug('EXCEPTION IN BUILD START EVENT : Unable to parse cypress support files', true, err);
+      return;
+    }
     files.forEach(file => {
       try {
         const fileName = path.basename(file);

--- a/bin/testObservability/helper/helper.js
+++ b/bin/testObservability/helper/helper.js
@@ -301,27 +301,29 @@ exports.setEventListeners = (bsConfig) => {
   try {
     const supportFilesData = helper.getSupportFiles(bsConfig, false);
     if(!supportFilesData.supportFile) return;
-    glob(process.cwd() + supportFilesData.supportFile, {}, (err, files) => {
-      if(err) return exports.debug('EXCEPTION IN BUILD START EVENT : Unable to parse cypress support files');
-      files.forEach(file => {
-        try {
-          if (isE2ESupportFile(file) || !files.some(f => isE2ESupportFile(f))) {
-            const defaultFileContent = fs.readFileSync(file, {encoding: 'utf-8'});
+    // Must be synchronous: runs.js proceeds to md5 hashing and zip archiving
+    // immediately after this returns. An async glob callback races the archive
+    // (SDK-7121) — a lost race ships an un-instrumented suite, and md5 caching
+    // makes it sticky, so TRA receives no test events.
+    const files = glob.sync(process.cwd() + supportFilesData.supportFile, {});
+    files.forEach(file => {
+      try {
+        if (isE2ESupportFile(file) || !files.some(f => isE2ESupportFile(f))) {
+          const defaultFileContent = fs.readFileSync(file, {encoding: 'utf-8'});
 
-            let cypressCommandEventListener = getCypressCommandEventListener(file.includes('js'));
-            if(!defaultFileContent.includes(cypressCommandEventListener)) {
-              let newFileContent =  defaultFileContent + 
-                                  '\n' +
-                                  cypressCommandEventListener +
-                                  '\n'
-              fs.writeFileSync(file, newFileContent, {encoding: 'utf-8'});
-              supportFileContentMap[file] = supportFilesData.cleanupParams ? supportFilesData.cleanupParams : defaultFileContent;
-            }
+          let cypressCommandEventListener = getCypressCommandEventListener(file.includes('js'));
+          if(!defaultFileContent.includes(cypressCommandEventListener)) {
+            let newFileContent =  defaultFileContent +
+                                '\n' +
+                                cypressCommandEventListener +
+                                '\n'
+            fs.writeFileSync(file, newFileContent, {encoding: 'utf-8'});
+            supportFileContentMap[file] = supportFilesData.cleanupParams ? supportFilesData.cleanupParams : defaultFileContent;
           }
-        } catch(e) {
-          exports.debug(`Unable to modify file contents for ${file} to set event listeners with error ${e}`, true, e);
         }
-      });
+      } catch(e) {
+        exports.debug(`Unable to modify file contents for ${file} to set event listeners with error ${e}`, true, e);
+      }
     });
   } catch(e) {
     exports.debug(`Unable to parse support files to set event listeners with error ${e}`, true, e);

--- a/test/unit/bin/testObservability/setEventListeners.js
+++ b/test/unit/bin/testObservability/setEventListeners.js
@@ -7,40 +7,74 @@ const os = require('os');
 const path = require('path');
 
 const o11yHelper = require('../../../../bin/testObservability/helper/helper');
+const a11yHelper = require('../../../../bin/accessibility-automation/helper');
 const baseHelper = require('../../../../bin/helpers/helper');
 
-// Regression guard for SDK-7121: the TRA support-file injection MUST land
+// Regression guard for SDK-7121: the support-file instrumentation MUST land
 // synchronously. runs.js calls setEventListeners(bsConfig) and then proceeds
 // immediately to md5 hashing + zip archiving. When the injection was deferred to
 // an async glob callback, it raced the archive — a lost race shipped an
 // un-instrumented suite, and md5 caching made it sticky, so the new Automate
 // dashboard (TRA) received zero test events.
-describe('testObservability setEventListeners', () => {
-  let tmpDir, cwdStub, getSupportFilesStub;
+describe('SDK-7121 synchronous support-file instrumentation', () => {
+  let tmpDir, supportPath, cwdStub, getSupportFilesStub;
 
-  beforeEach(() => {
+  const setupTmpProject = () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdk7121-'));
     fs.mkdirSync(path.join(tmpDir, 'cypress', 'support'), { recursive: true });
-    fs.writeFileSync(path.join(tmpDir, 'cypress', 'support', 'e2e.js'), '// user original support file\n');
-
+    supportPath = path.join(tmpDir, 'cypress', 'support', 'e2e.js');
+    fs.writeFileSync(supportPath, '// user original support file\n');
     cwdStub = sinon.stub(process, 'cwd').returns(tmpDir);
-    getSupportFilesStub = sinon.stub(baseHelper, 'getSupportFiles').returns({
-      supportFile: '/cypress/support/e2e.js',
-      cleanupParams: {}
+  };
+
+  afterEach(() => {
+    if (cwdStub) cwdStub.restore();
+    if (getSupportFilesStub) getSupportFilesStub.restore();
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+    cwdStub = getSupportFilesStub = tmpDir = undefined;
+  });
+
+  describe('testObservability setEventListeners', () => {
+    beforeEach(() => {
+      setupTmpProject();
+      process.env.BS_TESTOPS_BUILD_COMPLETED = 'true';
+      // non-magic path -> glob.sync resolves the exact file
+      getSupportFilesStub = sinon.stub(baseHelper, 'getSupportFiles').returns({
+        supportFile: '/cypress/support/e2e.js',
+        cleanupParams: {}
+      });
+    });
+
+    it('injects the observability require synchronously before returning', () => {
+      o11yHelper.setEventListeners({ run_settings: {} });
+      // Read exactly as md5/archive would — synchronously, right after the call.
+      const content = fs.readFileSync(supportPath, 'utf-8');
+      expect(content).to.include('browserstack-cypress-cli/bin/testObservability/cypress');
+    });
+
+    it('does not double-inject when called twice (idempotent)', () => {
+      o11yHelper.setEventListeners({ run_settings: {} });
+      o11yHelper.setEventListeners({ run_settings: {} });
+      const content = fs.readFileSync(supportPath, 'utf-8');
+      const occurrences = content.split('browserstack-cypress-cli/bin/testObservability/cypress').length - 1;
+      expect(occurrences).to.equal(1);
     });
   });
 
-  afterEach(() => {
-    cwdStub.restore();
-    getSupportFilesStub.restore();
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  });
+  describe('accessibility setAccessibilityEventListeners (glob-pattern branch)', () => {
+    beforeEach(() => {
+      setupTmpProject();
+      // magic pattern -> exercises the glob.sync branch fixed for SDK-7121
+      getSupportFilesStub = sinon.stub(baseHelper, 'getSupportFiles').returns({
+        supportFile: '/cypress/support/**/*.js',
+        cleanupParams: {}
+      });
+    });
 
-  it('injects the observability require synchronously before returning', () => {
-    o11yHelper.setEventListeners({ run_settings: {} });
-
-    // Read exactly as md5/archive would — synchronously, right after the call.
-    const content = fs.readFileSync(path.join(tmpDir, 'cypress', 'support', 'e2e.js'), 'utf-8');
-    expect(content).to.include("browserstack-cypress-cli/bin/testObservability/cypress");
+    it('injects the accessibility require synchronously before returning', () => {
+      a11yHelper.setAccessibilityEventListeners({ run_settings: {} });
+      const content = fs.readFileSync(supportPath, 'utf-8');
+      expect(content).to.include('browserstack-cypress-cli/bin/accessibility-automation/cypress');
+    });
   });
 });

--- a/test/unit/bin/testObservability/setEventListeners.js
+++ b/test/unit/bin/testObservability/setEventListeners.js
@@ -1,0 +1,46 @@
+'use strict';
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const o11yHelper = require('../../../../bin/testObservability/helper/helper');
+const baseHelper = require('../../../../bin/helpers/helper');
+
+// Regression guard for SDK-7121: the TRA support-file injection MUST land
+// synchronously. runs.js calls setEventListeners(bsConfig) and then proceeds
+// immediately to md5 hashing + zip archiving. When the injection was deferred to
+// an async glob callback, it raced the archive — a lost race shipped an
+// un-instrumented suite, and md5 caching made it sticky, so the new Automate
+// dashboard (TRA) received zero test events.
+describe('testObservability setEventListeners', () => {
+  let tmpDir, cwdStub, getSupportFilesStub;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdk7121-'));
+    fs.mkdirSync(path.join(tmpDir, 'cypress', 'support'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'cypress', 'support', 'e2e.js'), '// user original support file\n');
+
+    cwdStub = sinon.stub(process, 'cwd').returns(tmpDir);
+    getSupportFilesStub = sinon.stub(baseHelper, 'getSupportFiles').returns({
+      supportFile: '/cypress/support/e2e.js',
+      cleanupParams: {}
+    });
+  });
+
+  afterEach(() => {
+    cwdStub.restore();
+    getSupportFilesStub.restore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('injects the observability require synchronously before returning', () => {
+    o11yHelper.setEventListeners({ run_settings: {} });
+
+    // Read exactly as md5/archive would — synchronously, right after the call.
+    const content = fs.readFileSync(path.join(tmpDir, 'cypress', 'support', 'e2e.js'), 'utf-8');
+    expect(content).to.include("browserstack-cypress-cli/bin/testObservability/cypress");
+  });
+});


### PR DESCRIPTION
## Summary
The new Automate dashboard (TRA / Test Observability) received **no test events** for Cypress runs on a customer's DEV pipeline, while the old Automate dashboard worked and the same suite/CLI/packages worked on another environment. Ref: SDK-7121.

## Root cause
`setEventListeners` (bin/testObservability/helper/helper.js) injects the observability plugin into the user's Cypress support file:

```js
require('browserstack-cypress-cli/bin/testObservability/cypress');
```

It did this inside an **async `glob(pattern, {}, cb)` callback and returned immediately without awaiting it**. In `bin/commands/runs.js`, the caller proceeds **synchronously** to md5 hashing (`checkUploadedMd5`) and zip archiving (`archiver.archive`) right after the call. So the injection **raced the archive**:

- Race won (fast FS / UAT): instrumented suite is zipped → TRA works.
- Race lost (slower CI / customer DEV): the archive reads the **un-instrumented** support file → remote runner has no o11y plugin → **zero TRA events**.

Md5 caching makes a lost race **sticky**: once a non-instrumented zip is cached under the original-content md5, every subsequent run logs `"Skipping zip upload since BrowserStack already has your test suite..."` and reuses the bad zip. The old Automate dashboard is unaffected because it does not depend on the injected plugin — exactly the reported asymmetry.

## Reproduction
Calling `setEventListeners` and reading the support file synchronously afterwards (as md5/archive do):

```
before fix:  injected SYNCHRONOUSLY? false   (archive can ship un-instrumented suite)
after  fix:  injected SYNCHRONOUSLY? true
```

## Fix
- `setEventListeners` → use `glob.sync` so the support-file writes complete before the function returns.
- Applied the same fix to the identical race in `setAccessibilityEventListeners`' glob-pattern branch (bin/accessibility-automation/helper.js).

## Testing
- New regression test `test/unit/bin/testObservability/setEventListeners.js` — asserts the observability require is present **synchronously** after the call. Fails on unfixed code, passes with the fix.
- Existing `accessibility-automation/cypress` unit tests: green (6/6).
- `commands/runs.js` unit file shows the same pre-existing standalone failures with and without this change (unrelated `setUsageReportingFlag` assertions).

## Release
- [x] patch — bug fix
- Release note: Fix Cypress Test Observability (new Automate dashboard) receiving no test events on some CI pipelines due to a race between support-file instrumentation and test-suite archiving/caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
