### PR TITLE
change const to let for response variable in reporterHTML.js

### DIFF
--- a/bin/helpers/reporterHTML.js
+++ b/bin/helpers/reporterHTML.js
@@ -44,7 +44,7 @@ let reportGenerator = async (bsConfig, buildId, args, rawArgs, buildReportData, 
   setAxiosProxy(axiosConfig);
 
   try {
-    const response = await axios.get(options.url, axiosConfig);
+    let response = await axios.get(options.url, axiosConfig);
     logger.debug('Received reports data from upstream.');
     try {
       build = response.data;


### PR DESCRIPTION
In bin/helpers/reporterHTML.js, 'response' is declared as a 'const' at line 47, but reassigned inside error handling blocks at lines 68 and 72. This causes a fatal TypeError at runtime when error reporting triggers. Changing 'const' to 'let' resolves the issue.