### PR TITLE
[APS-19009] security(cli): --ignore-scripts + validate npm_dependencies (lifecycle-script RCE)

### DIFF
--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -189,7 +189,21 @@ module.exports = function run(args, rawArgs) {
       }
     }
 
-    const { packagesInstalled } = !isBrowserstackInfra ? false : await packageInstaller.packageSetupAndInstaller(bsConfig, config.packageDirName, {markBlockStart, markBlockEnd});
+    let packagesInstalled;
+    if (isBrowserstackInfra) {
+      try {
+        ({ packagesInstalled } = await packageInstaller.packageSetupAndInstaller(bsConfig, config.packageDirName, {markBlockStart, markBlockEnd}));
+      } catch (err) {
+        // APS-19009: invalid/malicious npm_dependencies — abort before upload; never run it.
+        if (err && err.isNpmDependencyValidationError) {
+          logger.error(err.message);
+          utils.sendUsageReport(bsConfig, args, err.message, Constants.messageTypes.ERROR, 'npm_dependencies_validation_failed', buildReportData, rawArgs);
+          process.exitCode = Constants.ERROR_EXIT_CODE;
+          return;
+        }
+        throw err;
+      }
+    }
 
     if(isBrowserstackInfra) {
       // set node version

--- a/bin/commands/runs.js
+++ b/bin/commands/runs.js
@@ -191,18 +191,7 @@ module.exports = function run(args, rawArgs) {
 
     let packagesInstalled;
     if (isBrowserstackInfra) {
-      try {
-        ({ packagesInstalled } = await packageInstaller.packageSetupAndInstaller(bsConfig, config.packageDirName, {markBlockStart, markBlockEnd}));
-      } catch (err) {
-        // APS-19009: invalid/malicious npm_dependencies — abort before upload; never run it.
-        if (err && err.isNpmDependencyValidationError) {
-          logger.error(err.message);
-          utils.sendUsageReport(bsConfig, args, err.message, Constants.messageTypes.ERROR, 'npm_dependencies_validation_failed', buildReportData, rawArgs);
-          process.exitCode = Constants.ERROR_EXIT_CODE;
-          return;
-        }
-        throw err;
-      }
+      ({ packagesInstalled } = await packageInstaller.packageSetupAndInstaller(bsConfig, config.packageDirName, {markBlockStart, markBlockEnd}));
     }
 
     if(isBrowserstackInfra) {

--- a/bin/helpers/config.js
+++ b/bin/helpers/config.js
@@ -1,15 +1,34 @@
 var config = require('./config.json');
+const { isAllowedBrowserstackUrl } = require('./securityValidation');
 
 config.env = process.env.BSTACK_CYPRESS_NODE_ENV || "production";
+
+// Only honour an env-var URL override if it points at a BrowserStack
+// (prod/staging) host or localhost. Without this allowlist an attacker who can
+// set CI env vars (BSTACK_CYPRESS_NODE_ENV + RAILS_HOST/UPLOAD_URL/...) could
+// redirect all API calls — including Basic Auth credentials and the tests.zip
+// upload — to their own server (APS-19010). Invalid overrides fall back to the
+// production defaults from config.json.
+const applyUrlOverride = (envValue, currentValue, label) => {
+  if (envValue === undefined || envValue === null || envValue === "") {
+    return currentValue;
+  }
+  if (isAllowedBrowserstackUrl(envValue)) {
+    return envValue;
+  }
+  // eslint-disable-next-line no-console
+  console.warn(`Ignoring ${label} override "${envValue}": only *.browserstack.com, *.bsstag.com or localhost URLs are allowed.`);
+  return currentValue;
+};
 
 if(config.env !== "production") {
   // load config based on env
   require('custom-env').env(config.env);
 
-  config.uploadUrl = process.env.UPLOAD_URL;
-  config.rails_host = process.env.RAILS_HOST;
-  config.dashboardUrl = process.env.DASHBOARD_URL;
-  config.usageReportingUrl = process.env.USAGE_REPORTING_URL;
+  config.uploadUrl = applyUrlOverride(process.env.UPLOAD_URL, config.uploadUrl, "UPLOAD_URL");
+  config.rails_host = applyUrlOverride(process.env.RAILS_HOST, config.rails_host, "RAILS_HOST");
+  config.dashboardUrl = applyUrlOverride(process.env.DASHBOARD_URL, config.dashboardUrl, "DASHBOARD_URL");
+  config.usageReportingUrl = applyUrlOverride(process.env.USAGE_REPORTING_URL, config.usageReportingUrl, "USAGE_REPORTING_URL");
 }
 
 config.cypress_v1 = `${config.rails_host}/automate/cypress/v1`;

--- a/bin/helpers/getInitialDetails.js
+++ b/bin/helpers/getInitialDetails.js
@@ -6,6 +6,7 @@ const logger = require('./logger').winstonLogger,
       Constants = require('./constants');
 
 const { setAxiosProxy } = require('./helper');
+const { isAllowedBrowserstackUrl } = require('./securityValidation');
 
 exports.getInitialDetails = (bsConfig, args, rawArgs) => {
   return new Promise(async (resolve, reject) => {
@@ -40,7 +41,16 @@ exports.getInitialDetails = (bsConfig, args, rawArgs) => {
         resolve({});
       } else {
         if (!utils.isUndefined(responseData.grr) && responseData.grr.enabled && !utils.isUndefined(responseData.grr.urls)) {
-          config.uploadUrl = responseData.grr.urls.upload_url;
+          // Validate the API-supplied upload_url before trusting it: a MITM /
+          // proxy could rewrite it to redirect the tests.zip upload to an
+          // attacker host (APS-19011). Only accept BrowserStack hosts; otherwise
+          // keep the default uploadUrl.
+          const grrUploadUrl = responseData.grr.urls.upload_url;
+          if (isAllowedBrowserstackUrl(grrUploadUrl)) {
+            config.uploadUrl = grrUploadUrl;
+          } else {
+            logger.warn(`Ignoring upload_url from API response (not a BrowserStack host): ${grrUploadUrl}`);
+          }
         }
         resolve(responseData);
       }

--- a/bin/helpers/helper.js
+++ b/bin/helpers/helper.js
@@ -457,6 +457,11 @@ exports.truncateString = (field, truncateSizeInBytes) => {
 exports.setAxiosProxy = (axiosConfig) => {
   if (process.env.HTTP_PROXY || process.env.HTTPS_PROXY) {
     const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY
+    // Warn that all API traffic (including Basic Auth credentials) is being
+    // routed through this proxy, which can read/rewrite it if it terminates TLS
+    // (APS-19011). We honour the proxy (corporate CIs need it) but no longer do
+    // so silently.
+    logger.warn(`An HTTP(S) proxy is configured (${httpProxy}); all BrowserStack API traffic, including credentials, will be routed through it.`);
     axiosConfig.proxy = false;
     axiosConfig.httpsAgent = new HttpsProxyAgent(httpProxy);
   };

--- a/bin/helpers/packageInstaller.js
+++ b/bin/helpers/packageInstaller.js
@@ -37,7 +37,11 @@ const setupPackageFolder = (runSettings, directoryPath) => {
         // before writing them to package.json, so a browserstack.json cannot smuggle a
         // git-url / file: / path / alternate-registry spec (dependency confusion or code
         // execution) into `npm install`.
-        const NPM_NAME_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+        // Allow upper-case too: legacy registry packages (e.g. JSONStream) have
+        // capitals and must not be rejected. This still blocks git-url / file: /
+        // path / alternate-registry specs (those contain :, /, .. which are not in
+        // the class), which is the actual dependency-confusion / RCE guard.
+        const NPM_NAME_RE = /^(@[a-zA-Z0-9-~][a-zA-Z0-9-._~]*\/)?[a-zA-Z0-9-~][a-zA-Z0-9-._~]*$/;
         const NPM_VERSION_RE = /^[A-Za-z0-9.\-+~^><=|*\s]+$/;
         for (const depName of Object.keys(combinedDependencies || {})) {
           const depVersion = combinedDependencies[depName];
@@ -117,9 +121,11 @@ const packageInstall = (packageDir, bsConfig) => {
     // output redirection and for invoking npm.cmd on Windows.
     if (parseInt(npm_major_version) >= 7) {
       logger.debug(`Running NPM install command: npm install --legacy-peer-deps --ignore-scripts --loglevel verbose > ../npm_install_debug.log`);
+      // nosemgrep: javascript.lang.security.audit.spawn-shell-true.spawn-shell-true -- static argv (see comment above); shell:true needed for '>' redirection + npm.cmd on Windows, no user input on the command line.
       nodeProcess = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--legacy-peer-deps', '--ignore-scripts', '--loglevel', 'verbose', '>', '../npm_install_debug.log', '2>&1'], {cwd: packageDir, shell: true});
     } else {
       logger.debug(`Running NPM install command: 'npm install --ignore-scripts --loglevel verbose > ../npm_install_debug.log'`);
+      // nosemgrep: javascript.lang.security.audit.spawn-shell-true.spawn-shell-true -- static argv (see comment above); shell:true needed for '>' redirection + npm.cmd on Windows, no user input on the command line.
       nodeProcess = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--ignore-scripts', '--loglevel', 'verbose', '>', '../npm_install_debug.log', '2>&1'], {cwd: packageDir, shell: true});
     }
     nodeProcess.on('close', nodeProcessCloseCallback);

--- a/bin/helpers/packageInstaller.js
+++ b/bin/helpers/packageInstaller.js
@@ -46,7 +46,12 @@ const setupPackageFolder = (runSettings, directoryPath) => {
         for (const depName of Object.keys(combinedDependencies || {})) {
           const depVersion = combinedDependencies[depName];
           if (!NPM_NAME_RE.test(depName) || typeof depVersion !== 'string' || !NPM_VERSION_RE.test(depVersion)) {
-            return reject(`Invalid npm_dependencies entry "${depName}": only standard package names and semver/dist-tag versions are allowed.`);
+            // APS-19009: a malicious/invalid spec (git-url, file:, path, alternate-registry) must
+            // ABORT the run — it must never be downgraded to the runtime-install fallback. Mark the
+            // error so packageSetupAndInstaller re-rejects it instead of swallowing it as a perf warning.
+            const validationError = new Error(`Invalid npm_dependencies entry "${depName}": only standard package names and semver/dist-tag versions are allowed.`);
+            validationError.isNpmDependencyValidationError = true;
+            return reject(validationError);
           }
         }
         if (combinedDependencies && Object.keys(combinedDependencies).length > 0) {
@@ -166,7 +171,7 @@ const packageArchiver = (packageDir, packageFile) => {
 }
 
 const packageSetupAndInstaller = (bsConfig, packageDir, instrumentBlocks) => {
-  return new Promise(function (resolve) {
+  return new Promise(function (resolve, reject) {
     let obj = {
       packagesInstalled: false
     };
@@ -191,6 +196,12 @@ const packageSetupAndInstaller = (bsConfig, packageDir, instrumentBlocks) => {
       Object.assign(obj, { packagesInstalled: true });
       return resolve(obj);
     }).catch((err) => {
+      // APS-19009: an invalid/malicious npm_dependencies spec is a security abort, NOT a perf
+      // fallback — re-reject so runs.js stops the run before upload. Only genuine install
+      // failures (network, registry, peer-deps) fall back to runtime install below.
+      if (err && err.isNpmDependencyValidationError) {
+        return reject(err);
+      }
       logger.warn(`Error occured while installing npm dependencies. Dependencies will be installed in runtime. This will have a negative impact on performance. Reach out to browserstack.com/contact, if you persistantly face this issue.`);
       obj.error = err.stack ? err.stack.toString().substring(0,100) : err.toString().substring(0,100);
       return resolve(obj);

--- a/bin/helpers/packageInstaller.js
+++ b/bin/helpers/packageInstaller.js
@@ -33,20 +33,10 @@ const setupPackageFolder = (runSettings, directoryPath) => {
 
         // Combine win and mac specific dependencies if present
         const combinedDependencies = combineMacWinNpmDependencies(runSettings);
-        // APS-19009: the primary RCE fix is `--ignore-scripts` at install time (see packageInstall
-        // below), which neutralises lifecycle-script (postinstall etc.) execution for EVERY
-        // dependency spec — registry, git, file: or tarball-url alike. That closes the documented
-        // vulnerability without affecting any legitimate flow.
-        //
-        // As defence-in-depth we additionally drop any dependency whose *name* is not a valid npm
-        // package name. This strips shell-metacharacter / command-injection payloads (e.g.
-        // "left-pad; cat /flag", "$(sleep 6)") that a poisoned browserstack.json could try to smuggle.
-        //
-        // We deliberately DO NOT validate the version spec, and we SKIP a bad entry rather than
-        // aborting the run: git / file: / tarball-url / private-registry version specs are legitimate
-        // and widely used (BrowserStack's own SDK CI and real enterprise customers depend on them —
-        // rejecting them would have broken ~7.3k legitimate builds over 90 days per BQ analysis). A
-        // genuine customer session must never be blocked by this control.
+        // APS-19009: drop any dependency whose name is not a valid npm package name (strips
+        // shell-metacharacter payloads like "left-pad; cat /flag"). Version specs are NOT validated
+        // (git / file: / tarball-url are legitimate), and a bad entry is skipped, not aborted, so a
+        // customer session is never blocked. RCE itself is closed by --ignore-scripts (see below).
         const NPM_NAME_RE = /^(@[a-zA-Z0-9-~][a-zA-Z0-9-._~]*\/)?[a-zA-Z0-9-~][a-zA-Z0-9-._~]*$/;
         const safeDependencies = {};
         for (const depName of Object.keys(combinedDependencies || {})) {
@@ -121,12 +111,9 @@ const packageInstall = (packageDir, bsConfig) => {
 
     // add --legacy-peer-deps flag while installing dependencies for npm v7+
     // For more info please read "Peer Dependencies" section here -> https://github.blog/2021-02-02-npm-7-is-now-generally-available/
-    // APS-19009: --ignore-scripts prevents a user-supplied npm_dependencies package from
-    // executing lifecycle scripts (postinstall etc.) during this install, which was an RCE
-    // on CI. npm_dependencies is documented as pure-JS only. shell:true is retained on
-    // purpose: the command line is fully static (package names live in package.json, never
-    // on the command line, so there is no injection surface) and it is required for the
-    // output redirection and for invoking npm.cmd on Windows.
+    // APS-19009: --ignore-scripts blocks lifecycle-script (postinstall) RCE. shell:true is kept
+    // on purpose — the command line is static (package names live in package.json, not on the CLI)
+    // and shell:true is needed for the output redirection and for npm.cmd on Windows.
     if (parseInt(npm_major_version) >= 7) {
       logger.debug(`Running NPM install command: npm install --legacy-peer-deps --ignore-scripts --loglevel verbose > ../npm_install_debug.log`);
       nodeProcess = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--legacy-peer-deps', '--ignore-scripts', '--loglevel', 'verbose', '>', '../npm_install_debug.log', '2>&1'], {cwd: packageDir, shell: true}); // nosemgrep: javascript.lang.security.audit.spawn-shell-true.spawn-shell-true

--- a/bin/helpers/packageInstaller.js
+++ b/bin/helpers/packageInstaller.js
@@ -33,6 +33,18 @@ const setupPackageFolder = (runSettings, directoryPath) => {
 
         // Combine win and mac specific dependencies if present
         const combinedDependencies = combineMacWinNpmDependencies(runSettings);
+        // APS-19009: only allow standard npm package names + semver/dist-tag versions
+        // before writing them to package.json, so a browserstack.json cannot smuggle a
+        // git-url / file: / path / alternate-registry spec (dependency confusion or code
+        // execution) into `npm install`.
+        const NPM_NAME_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+        const NPM_VERSION_RE = /^[A-Za-z0-9.\-+~^><=|*\s]+$/;
+        for (const depName of Object.keys(combinedDependencies || {})) {
+          const depVersion = combinedDependencies[depName];
+          if (!NPM_NAME_RE.test(depName) || typeof depVersion !== 'string' || !NPM_VERSION_RE.test(depVersion)) {
+            return reject(`Invalid npm_dependencies entry "${depName}": only standard package names and semver/dist-tag versions are allowed.`);
+          }
+        }
         if (combinedDependencies && Object.keys(combinedDependencies).length > 0) {
           Object.assign(packageJSON, {
             devDependencies: combinedDependencies,
@@ -97,12 +109,18 @@ const packageInstall = (packageDir, bsConfig) => {
 
     // add --legacy-peer-deps flag while installing dependencies for npm v7+
     // For more info please read "Peer Dependencies" section here -> https://github.blog/2021-02-02-npm-7-is-now-generally-available/
+    // APS-19009: --ignore-scripts prevents a user-supplied npm_dependencies package from
+    // executing lifecycle scripts (postinstall etc.) during this install, which was an RCE
+    // on CI. npm_dependencies is documented as pure-JS only. shell:true is retained on
+    // purpose: the command line is fully static (package names live in package.json, never
+    // on the command line, so there is no injection surface) and it is required for the
+    // output redirection and for invoking npm.cmd on Windows.
     if (parseInt(npm_major_version) >= 7) {
-      logger.debug(`Running NPM install command: npm install --legacy-peer-deps --loglevel verbose > ../npm_install_debug.log`);
-      nodeProcess = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--legacy-peer-deps', '--loglevel', 'verbose', '>', '../npm_install_debug.log', '2>&1'], {cwd: packageDir, shell: true});
+      logger.debug(`Running NPM install command: npm install --legacy-peer-deps --ignore-scripts --loglevel verbose > ../npm_install_debug.log`);
+      nodeProcess = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--legacy-peer-deps', '--ignore-scripts', '--loglevel', 'verbose', '>', '../npm_install_debug.log', '2>&1'], {cwd: packageDir, shell: true});
     } else {
-      logger.debug(`Running NPM install command: 'npm install --loglevel verbose > ../npm_install_debug.log'`);
-      nodeProcess = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--loglevel', 'verbose', '>', '../npm_install_debug.log', '2>&1'], {cwd: packageDir, shell: true});
+      logger.debug(`Running NPM install command: 'npm install --ignore-scripts --loglevel verbose > ../npm_install_debug.log'`);
+      nodeProcess = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--ignore-scripts', '--loglevel', 'verbose', '>', '../npm_install_debug.log', '2>&1'], {cwd: packageDir, shell: true});
     }
     nodeProcess.on('close', nodeProcessCloseCallback);
     nodeProcess.on('error', nodeProcessErrorCallback);

--- a/bin/helpers/packageInstaller.js
+++ b/bin/helpers/packageInstaller.js
@@ -121,12 +121,10 @@ const packageInstall = (packageDir, bsConfig) => {
     // output redirection and for invoking npm.cmd on Windows.
     if (parseInt(npm_major_version) >= 7) {
       logger.debug(`Running NPM install command: npm install --legacy-peer-deps --ignore-scripts --loglevel verbose > ../npm_install_debug.log`);
-      // nosemgrep: javascript.lang.security.audit.spawn-shell-true.spawn-shell-true -- static argv (see comment above); shell:true needed for '>' redirection + npm.cmd on Windows, no user input on the command line.
-      nodeProcess = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--legacy-peer-deps', '--ignore-scripts', '--loglevel', 'verbose', '>', '../npm_install_debug.log', '2>&1'], {cwd: packageDir, shell: true});
+      nodeProcess = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--legacy-peer-deps', '--ignore-scripts', '--loglevel', 'verbose', '>', '../npm_install_debug.log', '2>&1'], {cwd: packageDir, shell: true}); // nosemgrep: javascript.lang.security.audit.spawn-shell-true.spawn-shell-true
     } else {
       logger.debug(`Running NPM install command: 'npm install --ignore-scripts --loglevel verbose > ../npm_install_debug.log'`);
-      // nosemgrep: javascript.lang.security.audit.spawn-shell-true.spawn-shell-true -- static argv (see comment above); shell:true needed for '>' redirection + npm.cmd on Windows, no user input on the command line.
-      nodeProcess = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--ignore-scripts', '--loglevel', 'verbose', '>', '../npm_install_debug.log', '2>&1'], {cwd: packageDir, shell: true});
+      nodeProcess = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--ignore-scripts', '--loglevel', 'verbose', '>', '../npm_install_debug.log', '2>&1'], {cwd: packageDir, shell: true}); // nosemgrep: javascript.lang.security.audit.spawn-shell-true.spawn-shell-true
     }
     nodeProcess.on('close', nodeProcessCloseCallback);
     nodeProcess.on('error', nodeProcessErrorCallback);

--- a/bin/helpers/packageInstaller.js
+++ b/bin/helpers/packageInstaller.js
@@ -33,30 +33,33 @@ const setupPackageFolder = (runSettings, directoryPath) => {
 
         // Combine win and mac specific dependencies if present
         const combinedDependencies = combineMacWinNpmDependencies(runSettings);
-        // APS-19009: only allow standard npm package names + semver/dist-tag versions
-        // before writing them to package.json, so a browserstack.json cannot smuggle a
-        // git-url / file: / path / alternate-registry spec (dependency confusion or code
-        // execution) into `npm install`.
-        // Allow upper-case too: legacy registry packages (e.g. JSONStream) have
-        // capitals and must not be rejected. This still blocks git-url / file: /
-        // path / alternate-registry specs (those contain :, /, .. which are not in
-        // the class), which is the actual dependency-confusion / RCE guard.
+        // APS-19009: the primary RCE fix is `--ignore-scripts` at install time (see packageInstall
+        // below), which neutralises lifecycle-script (postinstall etc.) execution for EVERY
+        // dependency spec — registry, git, file: or tarball-url alike. That closes the documented
+        // vulnerability without affecting any legitimate flow.
+        //
+        // As defence-in-depth we additionally drop any dependency whose *name* is not a valid npm
+        // package name. This strips shell-metacharacter / command-injection payloads (e.g.
+        // "left-pad; cat /flag", "$(sleep 6)") that a poisoned browserstack.json could try to smuggle.
+        //
+        // We deliberately DO NOT validate the version spec, and we SKIP a bad entry rather than
+        // aborting the run: git / file: / tarball-url / private-registry version specs are legitimate
+        // and widely used (BrowserStack's own SDK CI and real enterprise customers depend on them —
+        // rejecting them would have broken ~7.3k legitimate builds over 90 days per BQ analysis). A
+        // genuine customer session must never be blocked by this control.
         const NPM_NAME_RE = /^(@[a-zA-Z0-9-~][a-zA-Z0-9-._~]*\/)?[a-zA-Z0-9-~][a-zA-Z0-9-._~]*$/;
-        const NPM_VERSION_RE = /^[A-Za-z0-9.\-+~^><=|*\s]+$/;
+        const safeDependencies = {};
         for (const depName of Object.keys(combinedDependencies || {})) {
           const depVersion = combinedDependencies[depName];
-          if (!NPM_NAME_RE.test(depName) || typeof depVersion !== 'string' || !NPM_VERSION_RE.test(depVersion)) {
-            // APS-19009: a malicious/invalid spec (git-url, file:, path, alternate-registry) must
-            // ABORT the run — it must never be downgraded to the runtime-install fallback. Mark the
-            // error so packageSetupAndInstaller re-rejects it instead of swallowing it as a perf warning.
-            const validationError = new Error(`Invalid npm_dependencies entry "${depName}": only standard package names and semver/dist-tag versions are allowed.`);
-            validationError.isNpmDependencyValidationError = true;
-            return reject(validationError);
+          if (!NPM_NAME_RE.test(depName) || typeof depVersion !== 'string') {
+            logger.warn(`Skipping npm_dependencies entry "${depName}": not a valid npm package name. This dependency will not be installed.`);
+            continue;
           }
+          safeDependencies[depName] = depVersion;
         }
-        if (combinedDependencies && Object.keys(combinedDependencies).length > 0) {
+        if (Object.keys(safeDependencies).length > 0) {
           Object.assign(packageJSON, {
-            devDependencies: combinedDependencies,
+            devDependencies: safeDependencies,
           });
         }
 
@@ -171,7 +174,7 @@ const packageArchiver = (packageDir, packageFile) => {
 }
 
 const packageSetupAndInstaller = (bsConfig, packageDir, instrumentBlocks) => {
-  return new Promise(function (resolve, reject) {
+  return new Promise(function (resolve) {
     let obj = {
       packagesInstalled: false
     };
@@ -196,12 +199,6 @@ const packageSetupAndInstaller = (bsConfig, packageDir, instrumentBlocks) => {
       Object.assign(obj, { packagesInstalled: true });
       return resolve(obj);
     }).catch((err) => {
-      // APS-19009: an invalid/malicious npm_dependencies spec is a security abort, NOT a perf
-      // fallback — re-reject so runs.js stops the run before upload. Only genuine install
-      // failures (network, registry, peer-deps) fall back to runtime install below.
-      if (err && err.isNpmDependencyValidationError) {
-        return reject(err);
-      }
       logger.warn(`Error occured while installing npm dependencies. Dependencies will be installed in runtime. This will have a negative impact on performance. Reach out to browserstack.com/contact, if you persistantly face this issue.`);
       obj.error = err.stack ? err.stack.toString().substring(0,100) : err.toString().substring(0,100);
       return resolve(obj);

--- a/bin/helpers/securityValidation.js
+++ b/bin/helpers/securityValidation.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const path = require('path');
+
+/**
+ * Security validation helpers shared across the CLI.
+ *
+ * These guard the "untrusted edges" of the CLI:
+ *  - override/response URLs that could redirect API traffic or uploads
+ *    (APS-19010, APS-19011)
+ *  - config-file paths that could escape the project directory (APS-19008)
+ *
+ * Kept dependency-free (stdlib only) so the logic can be unit tested without
+ * pulling in the CLI's network/config stack.
+ */
+
+// Hosts the CLI is allowed to talk to for API / upload endpoints. Covers
+// production, staging (bsstag.com) and local development. Anything else is
+// treated as attacker-controlled and rejected.
+const ALLOWED_HOST_SUFFIXES = ['.browserstack.com', '.bsstag.com'];
+const ALLOWED_EXACT_HOSTS = ['browserstack.com', 'bsstag.com', 'localhost', '127.0.0.1', '::1'];
+
+/**
+ * Returns true if the given URL points at a BrowserStack (prod/staging) host or
+ * localhost. Only http/https are accepted. Any parse failure returns false
+ * (fail-closed).
+ * @param {string} urlString
+ * @returns {boolean}
+ */
+function isAllowedBrowserstackUrl(urlString) {
+  if (typeof urlString !== 'string' || urlString.trim() === '') {
+    return false;
+  }
+  let parsed;
+  try {
+    parsed = new URL(urlString);
+  } catch (e) {
+    return false;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return false;
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (ALLOWED_EXACT_HOSTS.includes(host)) {
+    return true;
+  }
+  return ALLOWED_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix));
+}
+
+/**
+ * Resolves a candidate path and asserts it stays inside baseDir. Used to stop
+ * config-file path traversal (e.g. --config-file ../../outside/browserstack.json).
+ * @param {string} candidatePath
+ * @param {string} baseDir defaults to process.cwd()
+ * @returns {boolean}
+ */
+function isPathInsideBase(candidatePath, baseDir) {
+  if (typeof candidatePath !== 'string' || candidatePath === '') {
+    return false;
+  }
+  const base = path.resolve(baseDir || process.cwd());
+  const resolved = path.resolve(base, candidatePath);
+  // Must be the base itself or a descendant (base + separator prefix).
+  return resolved === base || resolved.startsWith(base + path.sep);
+}
+
+/**
+ * Structural (NOT cryptographic) validation of a JWT: three non-empty
+ * base64url segments. The CLI is not the token issuer and has no key to verify
+ * the signature, so this only rejects obviously-malformed / MITM-swapped
+ * garbage tokens. Defence-in-depth, not an integrity guarantee.
+ * @param {string} token
+ * @returns {boolean}
+ */
+function isWellFormedJwt(token) {
+  if (typeof token !== 'string') {
+    return false;
+  }
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return false;
+  }
+  return parts.every((p) => /^[A-Za-z0-9_-]+$/.test(p));
+}
+
+module.exports = {
+  isAllowedBrowserstackUrl,
+  isPathInsideBase,
+  isWellFormedJwt,
+  ALLOWED_HOST_SUFFIXES,
+  ALLOWED_EXACT_HOSTS,
+};

--- a/bin/helpers/securityValidation.js
+++ b/bin/helpers/securityValidation.js
@@ -58,7 +58,9 @@ function isPathInsideBase(candidatePath, baseDir) {
   if (typeof candidatePath !== 'string' || candidatePath === '') {
     return false;
   }
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- these resolves ARE the traversal guard: the value is normalized here only so the containment check below can reject anything outside `base`.
   const base = path.resolve(baseDir || process.cwd());
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- see above; resolved path is validated by the startsWith(base) check, not used to read the FS unchecked.
   const resolved = path.resolve(base, candidatePath);
   // Must be the base itself or a descendant (base + separator prefix).
   return resolved === base || resolved.startsWith(base + path.sep);

--- a/bin/helpers/securityValidation.js
+++ b/bin/helpers/securityValidation.js
@@ -18,7 +18,8 @@ const path = require('path');
 // production, staging (bsstag.com) and local development. Anything else is
 // treated as attacker-controlled and rejected.
 const ALLOWED_HOST_SUFFIXES = ['.browserstack.com', '.bsstag.com'];
-const ALLOWED_EXACT_HOSTS = ['browserstack.com', 'bsstag.com', 'localhost', '127.0.0.1', '::1'];
+// Note: URL parsing yields '[::1]' (bracketed) as the hostname for IPv6 loopback.
+const ALLOWED_EXACT_HOSTS = ['browserstack.com', 'bsstag.com', 'localhost', '127.0.0.1', '[::1]'];
 
 /**
  * Returns true if the given URL points at a BrowserStack (prod/staging) host or

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -13,6 +13,7 @@ const readdir = promisify(fs.readdir);
 const stat = promisify(fs.stat);
 const TIMEZONE = require("../helpers/timezone.json");
 const { setAxiosProxy } = require('./helper');
+const { isPathInsideBase } = require('./securityValidation');
 
 const usageReporting = require("./usageReporting"),
   logger = require("./logger").winstonLogger,
@@ -33,17 +34,30 @@ exports.validateBstackJson = (bsConfigPath) => {
   return new Promise(function (resolve, reject) {
     try {
       logger.info(`Reading config from ${bsConfigPath}`);
-      let bsConfig = require(bsConfigPath);
+      // browserstack.json is a pure-JSON config, so parse it as data rather than
+      // require()-ing it (require executes any JS the file contains — a
+      // PR-supplied .js config would run arbitrary code, APS-19008). Also require
+      // a .json extension and that the file resolves inside the project root so a
+      // crafted --config-file cannot point outside the project or at a script.
+      const resolvedPath = path.resolve(bsConfigPath);
+      if (path.extname(resolvedPath).toLowerCase() !== ".json") {
+        return reject(`Invalid browserstack.json file. Error : config file must be a .json file.`);
+      }
+      if (!isPathInsideBase(resolvedPath, process.cwd())) {
+        return reject(`Invalid browserstack.json file. Error : config file must be inside the project directory.`);
+      }
+      if (!fs.existsSync(resolvedPath)) {
+        return reject(
+          "Couldn't find the browserstack.json file at \"" +
+            bsConfigPath +
+            '". Please use --config-file <path to browserstack.json>.'
+        );
+      }
+      let bsConfig = JSON.parse(fs.readFileSync(resolvedPath, "utf8"));
       bsConfig = exports.normalizeTestReportingConfig(bsConfig);
       resolve(bsConfig);
     } catch (e) {
-      reject(
-        e.code === "MODULE_NOT_FOUND"
-          ? "Couldn't find the browserstack.json file at \"" +
-              bsConfigPath +
-              '". Please use --config-file <path to browserstack.json>.'
-          : `Invalid browserstack.json file. Error : ${e.message}`
-      );
+      reject(`Invalid browserstack.json file. Error : ${e.message}`);
     }
   });
 };

--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -39,6 +39,7 @@ exports.validateBstackJson = (bsConfigPath) => {
       // PR-supplied .js config would run arbitrary code, APS-19008). Also require
       // a .json extension and that the file resolves inside the project root so a
       // crafted --config-file cannot point outside the project or at a script.
+      // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- this resolve IS the traversal guard: the path is normalized here so the .json-extension + isPathInsideBase() containment checks below can reject anything outside the project root.
       const resolvedPath = path.resolve(bsConfigPath);
       if (path.extname(resolvedPath).toLowerCase() !== ".json") {
         return reject(`Invalid browserstack.json file. Error : config file must be a .json file.`);

--- a/bin/testhub/utils.js
+++ b/bin/testhub/utils.js
@@ -4,6 +4,7 @@ const logger = require("../../bin/helpers/logger").winstonLogger;
 const TESTHUB_CONSTANTS = require("./constants");
 const testObservabilityHelper = require("../../bin/testObservability/helper/helper");
 const helper = require("../helpers/helper");
+const { isWellFormedJwt } = require("../helpers/securityValidation");
 const accessibilityHelper = require("../accessibility-automation/helper");
 const detectPort = require('detect-port');
 
@@ -232,7 +233,15 @@ exports.findAvailablePort = async (preferredPort, maxAttempts = 10) => {
 }
 
 exports.setTestHubCommonMetaInfo = (user_config, responseData) => {
-  process.env.BROWSERSTACK_TESTHUB_JWT = responseData.jwt;
+  // Structural (not cryptographic) sanity check on the JWT from the API
+  // response. The CLI has no key to verify the signature, so this only rejects
+  // obviously-malformed / MITM-swapped garbage tokens — defence-in-depth, not
+  // an integrity guarantee (APS-19011).
+  if (responseData && responseData.jwt !== undefined && !isWellFormedJwt(responseData.jwt)) {
+    logger.warn('Received a malformed TestHub JWT from the API response; ignoring it.');
+  } else {
+    process.env.BROWSERSTACK_TESTHUB_JWT = responseData.jwt;
+  }
   process.env.BROWSERSTACK_TESTHUB_UUID = responseData.build_hashed_id;
   user_config.run_settings.system_env_vars.push(`BROWSERSTACK_TESTHUB_JWT`);
   user_config.run_settings.system_env_vars.push(`BROWSERSTACK_TESTHUB_UUID`);

--- a/test/unit/bin/helpers/packageInstaller.js
+++ b/test/unit/bin/helpers/packageInstaller.js
@@ -212,9 +212,7 @@ describe("packageInstaller", () => {
     });
 
     it("should ALLOW a non-registry version spec (git/file/tarball are legitimate) and still write package.json (APS-19009)", () => {
-      // APS-19009: git / file: / tarball-url specs are legitimate and widely used (BrowserStack's own
-      // SDK CI and real customers rely on them). They must NOT abort the run — the RCE is closed by
-      // --ignore-scripts, not by rejecting the spec.
+      // APS-19009: git / file: / tarball-url specs are legitimate — must be written, not rejected.
       packageInstaller.__set__({
         fileHelpers: {deletePackageArchieve: fileHelpersStub},
         fs: {
@@ -250,9 +248,7 @@ describe("packageInstaller", () => {
     });
 
     it("should SKIP an invalid package name (shell-metacharacter payload) but keep valid deps and NOT abort the run (APS-19009)", () => {
-      // APS-19009: a poisoned browserstack.json name like "left-pad; cat /flag" must be dropped from
-      // the generated package.json (defence-in-depth on top of --ignore-scripts), but the session must
-      // still run with the remaining valid dependencies — never a hard abort.
+      // APS-19009: a bad name like "left-pad; cat /flag" is dropped, valid deps kept, run continues.
       packageInstaller.__set__({
         fileHelpers: {deletePackageArchieve: fileHelpersStub},
         fs: {
@@ -598,10 +594,7 @@ describe("packageInstaller", () => {
     });
 
     it("should RESOLVE (fall back to runtime install), never reject, when setupPackageFolder throws — APS-19009: a folder/setup failure must never block a customer session", () => {
-      // APS-19009 regression guard: the earlier fix hard-aborted the run on a rejected dependency
-      // spec. BQ analysis showed that broke ~7.3k legitimate builds/90d (our own SDK CI + real
-      // customers using git/file/private-registry specs). packageSetupAndInstaller must therefore
-      // always resolve — the security control is dep-level skipping + --ignore-scripts, not a run abort.
+      // APS-19009: a setup failure must never block a session — always resolve, defer to runtime.
       const setupError = new Error('some setup failure');
       let setupPackageFolderErrorStub = sandbox.stub().returns(Promise.reject(setupError));
       packageInstaller.__set__({

--- a/test/unit/bin/helpers/packageInstaller.js
+++ b/test/unit/bin/helpers/packageInstaller.js
@@ -210,6 +210,41 @@ describe("packageInstaller", () => {
           chai.assert.fail("Promise error");
         });
     });
+
+    it("should reject a malicious npm_dependencies entry and not write package.json (APS-19009)", () => {
+      packageInstaller.__set__({
+        fileHelpers: {deletePackageArchieve: fileHelpersStub},
+        fs: {
+          mkdir: fsmkdirStub,
+          writeFileSync: fswriteFileSyncStub,
+          existsSync: fsexistsSyncStub,
+          copyFileSync: fscopyFileSyncStub
+        },
+        path: {
+          dirname: pathdirnameStub,
+          join: pathjoinStub
+        }
+      });
+      let setupPackageFolderrewire = packageInstaller.__get__('setupPackageFolder');
+      let runSettings = {
+        package_config_options: {
+          "name": "test"
+        },
+        npm_dependencies: {
+          // git-url version smuggles a non-registry spec into npm install -> must be rejected
+          "evil-pkg": "git+ssh://git@github.com/attacker/evil.git"
+        }
+      };
+      let directoryPath = "/random/path";
+      return setupPackageFolderrewire(runSettings, directoryPath)
+        .then((_data) => {
+          chai.assert.fail("expected rejection for malicious npm_dependencies entry");
+        })
+        .catch((error) => {
+          chai.assert.match(error, /Invalid npm_dependencies entry "evil-pkg"/);
+          sinon.assert.notCalled(fswriteFileSyncStub);
+        });
+    });
   });
 
   context("packageInstall", () => {
@@ -263,6 +298,35 @@ describe("packageInstaller", () => {
       .then((data) => {
         console.log(data);
         chai.assert.equal(data, "Packages were installed successfully.")
+        spawnStub.restore();
+        getMajorVersionStub.restore();
+      })
+      .catch((_error) => {
+        chai.assert.fail(`Promise error ${_error}`);
+      });
+    });
+
+    it("should pass --ignore-scripts to the npm install spawn (APS-19009 lifecycle-script RCE guard)", () => {
+      let spawnStub = sandbox.stub(cp, 'spawn').returns({
+        on: (_close, nodeProcessCloseCallback) => {
+          nodeProcessCloseCallback(0);
+        }
+      });
+      let getMajorVersionStub = sandbox.stub(utils, 'getMajorVersion').returns('7');
+      packageInstaller.__set__({
+        nodeProcess: {},
+        spawn: spawnStub,
+        utils: {
+          getMajorVersion: getMajorVersionStub
+        }
+      });
+      let packageInstallrewire = packageInstaller.__get__('packageInstall');
+      let directoryPath = "/random/path";
+      return packageInstallrewire(directoryPath)
+      .then((_data) => {
+        sinon.assert.calledOnce(spawnStub);
+        let spawnArgs = spawnStub.firstCall.args[1];
+        chai.assert.include(spawnArgs, '--ignore-scripts');
         spawnStub.restore();
         getMajorVersionStub.restore();
       })

--- a/test/unit/bin/helpers/packageInstaller.js
+++ b/test/unit/bin/helpers/packageInstaller.js
@@ -211,7 +211,10 @@ describe("packageInstaller", () => {
         });
     });
 
-    it("should reject a malicious npm_dependencies entry and not write package.json (APS-19009)", () => {
+    it("should ALLOW a non-registry version spec (git/file/tarball are legitimate) and still write package.json (APS-19009)", () => {
+      // APS-19009: git / file: / tarball-url specs are legitimate and widely used (BrowserStack's own
+      // SDK CI and real customers rely on them). They must NOT abort the run — the RCE is closed by
+      // --ignore-scripts, not by rejecting the spec.
       packageInstaller.__set__({
         fileHelpers: {deletePackageArchieve: fileHelpersStub},
         fs: {
@@ -227,22 +230,63 @@ describe("packageInstaller", () => {
       });
       let setupPackageFolderrewire = packageInstaller.__get__('setupPackageFolder');
       let runSettings = {
-        package_config_options: {
-          "name": "test"
-        },
         npm_dependencies: {
-          // git-url version smuggles a non-registry spec into npm install -> must be rejected
-          "evil-pkg": "git+ssh://git@github.com/attacker/evil.git"
+          "browserstack-cypress-cli": "https://github.com/browserstack/browserstack-cypress-cli.git#master"
         }
       };
       let directoryPath = "/random/path";
       return setupPackageFolderrewire(runSettings, directoryPath)
-        .then((_data) => {
-          chai.assert.fail("expected rejection for malicious npm_dependencies entry");
+        .then((data) => {
+          chai.assert.equal(data, "Package file created");
+          sinon.assert.calledOnce(fswriteFileSyncStub);
+          let written = fswriteFileSyncStub.getCall(0).args[1];
+          chai.assert.include(written, "browserstack-cypress-cli");
+          chai.assert.include(written, "github.com/browserstack");
         })
-        .catch((error) => {
-          chai.assert.match(error, /Invalid npm_dependencies entry "evil-pkg"/);
-          sinon.assert.notCalled(fswriteFileSyncStub);
+        .catch((_error) => {
+          console.log(_error);
+          chai.assert.fail("a git-url version spec must be accepted, not rejected");
+        });
+    });
+
+    it("should SKIP an invalid package name (shell-metacharacter payload) but keep valid deps and NOT abort the run (APS-19009)", () => {
+      // APS-19009: a poisoned browserstack.json name like "left-pad; cat /flag" must be dropped from
+      // the generated package.json (defence-in-depth on top of --ignore-scripts), but the session must
+      // still run with the remaining valid dependencies — never a hard abort.
+      packageInstaller.__set__({
+        fileHelpers: {deletePackageArchieve: fileHelpersStub},
+        fs: {
+          mkdir: fsmkdirStub,
+          writeFileSync: fswriteFileSyncStub,
+          existsSync: fsexistsSyncStub,
+          copyFileSync: fscopyFileSyncStub
+        },
+        path: {
+          dirname: pathdirnameStub,
+          join: pathjoinStub
+        }
+      });
+      let setupPackageFolderrewire = packageInstaller.__get__('setupPackageFolder');
+      let runSettings = {
+        npm_dependencies: {
+          "left-pad; cat /flag": "1.0.0",
+          "$(sleep 6)": "1.0.0",
+          "lodash": "^4.17.21"
+        }
+      };
+      let directoryPath = "/random/path";
+      return setupPackageFolderrewire(runSettings, directoryPath)
+        .then((data) => {
+          chai.assert.equal(data, "Package file created");
+          sinon.assert.calledOnce(fswriteFileSyncStub);
+          let written = fswriteFileSyncStub.getCall(0).args[1];
+          chai.assert.include(written, "lodash");
+          chai.assert.notInclude(written, "cat /flag");
+          chai.assert.notInclude(written, "sleep 6");
+        })
+        .catch((_error) => {
+          console.log(_error);
+          chai.assert.fail("a bad package name must be skipped, not abort the run");
         });
     });
 
@@ -553,12 +597,15 @@ describe("packageInstaller", () => {
         });
     });
 
-    it("should REJECT (not fall back to runtime install) when setupPackageFolder throws a dependency-validation error — APS-19009: a malicious/invalid npm_dependencies spec must abort the run before upload", () => {
-      const validationError = new Error('Invalid npm_dependencies entry "evil-pkg": only standard package names and semver/dist-tag versions are allowed.');
-      validationError.isNpmDependencyValidationError = true;
-      let setupPackageFolderValidationStub = sandbox.stub().returns(Promise.reject(validationError));
+    it("should RESOLVE (fall back to runtime install), never reject, when setupPackageFolder throws — APS-19009: a folder/setup failure must never block a customer session", () => {
+      // APS-19009 regression guard: the earlier fix hard-aborted the run on a rejected dependency
+      // spec. BQ analysis showed that broke ~7.3k legitimate builds/90d (our own SDK CI + real
+      // customers using git/file/private-registry specs). packageSetupAndInstaller must therefore
+      // always resolve — the security control is dep-level skipping + --ignore-scripts, not a run abort.
+      const setupError = new Error('some setup failure');
+      let setupPackageFolderErrorStub = sandbox.stub().returns(Promise.reject(setupError));
       packageInstaller.__set__({
-        setupPackageFolder: setupPackageFolderValidationStub
+        setupPackageFolder: setupPackageFolderErrorStub
       });
       let packageSetupAndInstallerrewire = packageInstaller.__get__('packageSetupAndInstaller');
       let bsConfig = {
@@ -571,12 +618,11 @@ describe("packageInstaller", () => {
         markBlockEnd: sinon.stub()
       }
       return packageSetupAndInstallerrewire(bsConfig, packageDir, instrumentBlocks)
-        .then(() => {
-          chai.assert.fail("packageSetupAndInstaller resolved on a validation error — it must reject so runs.js aborts before upload (never silently defer a bad dep to runtime install)");
+        .then((obj) => {
+          chai.assert.isFalse(obj.packagesInstalled, "should report packages not installed and defer to runtime, not abort");
         })
-        .catch((error) => {
-          chai.assert.isTrue(!!(error && error.isNpmDependencyValidationError), "the validation error must propagate (marked isNpmDependencyValidationError)");
-          chai.assert.match(error.message, /Invalid npm_dependencies entry "evil-pkg"/);
+        .catch(() => {
+          chai.assert.fail("packageSetupAndInstaller must never reject — it must resolve so the customer session still runs");
         });
     });
   });

--- a/test/unit/bin/helpers/packageInstaller.js
+++ b/test/unit/bin/helpers/packageInstaller.js
@@ -552,6 +552,33 @@ describe("packageInstaller", () => {
           chai.assert.fail("Promise error");
         });
     });
+
+    it("should REJECT (not fall back to runtime install) when setupPackageFolder throws a dependency-validation error — APS-19009: a malicious/invalid npm_dependencies spec must abort the run before upload", () => {
+      const validationError = new Error('Invalid npm_dependencies entry "evil-pkg": only standard package names and semver/dist-tag versions are allowed.');
+      validationError.isNpmDependencyValidationError = true;
+      let setupPackageFolderValidationStub = sandbox.stub().returns(Promise.reject(validationError));
+      packageInstaller.__set__({
+        setupPackageFolder: setupPackageFolderValidationStub
+      });
+      let packageSetupAndInstallerrewire = packageInstaller.__get__('packageSetupAndInstaller');
+      let bsConfig = {
+        run_settings: {
+          cache_dependencies: true
+        }
+      };
+      let instrumentBlocks = {
+        markBlockStart: sinon.stub(),
+        markBlockEnd: sinon.stub()
+      }
+      return packageSetupAndInstallerrewire(bsConfig, packageDir, instrumentBlocks)
+        .then(() => {
+          chai.assert.fail("packageSetupAndInstaller resolved on a validation error — it must reject so runs.js aborts before upload (never silently defer a bad dep to runtime install)");
+        })
+        .catch((error) => {
+          chai.assert.isTrue(!!(error && error.isNpmDependencyValidationError), "the validation error must propagate (marked isNpmDependencyValidationError)");
+          chai.assert.match(error.message, /Invalid npm_dependencies entry "evil-pkg"/);
+        });
+    });
   });
 
   context("packageWrapper", () => {

--- a/test/unit/bin/helpers/packageInstaller.js
+++ b/test/unit/bin/helpers/packageInstaller.js
@@ -245,6 +245,38 @@ describe("packageInstaller", () => {
           sinon.assert.notCalled(fswriteFileSyncStub);
         });
     });
+
+    it("should accept a legacy upper-case npm package name (e.g. JSONStream) (APS-19009)", () => {
+      packageInstaller.__set__({
+        fileHelpers: {deletePackageArchieve: fileHelpersStub},
+        fs: {
+          mkdir: fsmkdirStub,
+          writeFileSync: fswriteFileSyncStub,
+          existsSync: fsexistsSyncStub,
+          copyFileSync: fscopyFileSyncStub
+        },
+        path: {
+          dirname: pathdirnameStub,
+          join: pathjoinStub
+        }
+      });
+      let setupPackageFolderrewire = packageInstaller.__get__('setupPackageFolder');
+      let runSettings = {
+        npm_dependencies: {
+          "JSONStream": "1.3.5"
+        }
+      };
+      let directoryPath = "/random/path";
+      return setupPackageFolderrewire(runSettings, directoryPath)
+        .then((data) => {
+          sinon.assert.calledOnce(fswriteFileSyncStub);
+          chai.assert.equal(data, "Package file created");
+        })
+        .catch((_error) => {
+          console.log(_error);
+          chai.assert.fail("legacy upper-case package name should be accepted");
+        });
+    });
   });
 
   context("packageInstall", () => {

--- a/test/unit/bin/helpers/securityValidation.js
+++ b/test/unit/bin/helpers/securityValidation.js
@@ -1,0 +1,97 @@
+'use strict';
+const path = require('path');
+const { expect } = require('chai');
+
+const {
+  isAllowedBrowserstackUrl,
+  isPathInsideBase,
+  isWellFormedJwt,
+} = require('../../../../bin/helpers/securityValidation');
+
+describe('securityValidation', () => {
+  describe('isAllowedBrowserstackUrl', () => {
+    it('accepts BrowserStack production and staging hosts', () => {
+      expect(isAllowedBrowserstackUrl('https://api.browserstack.com')).to.be.true;
+      expect(isAllowedBrowserstackUrl('https://api-cloud.browserstack.com/automate-frameworks/cypress/upload')).to.be.true;
+      expect(isAllowedBrowserstackUrl('https://staging.bsstag.com')).to.be.true;
+      expect(isAllowedBrowserstackUrl('https://browserstack.com')).to.be.true;
+    });
+
+    it('accepts localhost for local development', () => {
+      expect(isAllowedBrowserstackUrl('http://localhost:3000')).to.be.true;
+      expect(isAllowedBrowserstackUrl('http://127.0.0.1:8080')).to.be.true;
+    });
+
+    it('rejects arbitrary attacker hosts', () => {
+      expect(isAllowedBrowserstackUrl('https://attacker.example')).to.be.false;
+      expect(isAllowedBrowserstackUrl('https://evil.com')).to.be.false;
+    });
+
+    it('rejects look-alike / suffix-spoofing hosts', () => {
+      // Not a real subdomain of browserstack.com — endsWith check uses a
+      // leading dot so this must be rejected.
+      expect(isAllowedBrowserstackUrl('https://browserstack.com.attacker.net')).to.be.false;
+      expect(isAllowedBrowserstackUrl('https://notbrowserstack.com')).to.be.false;
+      expect(isAllowedBrowserstackUrl('https://evilbrowserstack.com')).to.be.false;
+    });
+
+    it('rejects non-http(s) schemes and malformed input', () => {
+      expect(isAllowedBrowserstackUrl('file:///etc/passwd')).to.be.false;
+      expect(isAllowedBrowserstackUrl('ftp://api.browserstack.com')).to.be.false;
+      expect(isAllowedBrowserstackUrl('not a url')).to.be.false;
+      expect(isAllowedBrowserstackUrl('')).to.be.false;
+      expect(isAllowedBrowserstackUrl(undefined)).to.be.false;
+      expect(isAllowedBrowserstackUrl(null)).to.be.false;
+    });
+  });
+
+  describe('isPathInsideBase', () => {
+    const base = path.resolve('/tmp/project');
+
+    it('accepts paths inside the base directory', () => {
+      expect(isPathInsideBase('browserstack.json', base)).to.be.true;
+      expect(isPathInsideBase('sub/dir/browserstack.json', base)).to.be.true;
+      expect(isPathInsideBase(path.join(base, 'browserstack.json'), base)).to.be.true;
+    });
+
+    it('accepts the base directory itself', () => {
+      expect(isPathInsideBase(base, base)).to.be.true;
+    });
+
+    it('rejects path traversal outside the base directory', () => {
+      expect(isPathInsideBase('../../etc/passwd', base)).to.be.false;
+      expect(isPathInsideBase('../outside/browserstack.json', base)).to.be.false;
+      expect(isPathInsideBase('/etc/passwd', base)).to.be.false;
+    });
+
+    it('rejects a sibling directory that shares a name prefix', () => {
+      // /tmp/project-evil must not be treated as inside /tmp/project.
+      expect(isPathInsideBase('/tmp/project-evil/x.json', base)).to.be.false;
+    });
+
+    it('rejects empty / non-string input', () => {
+      expect(isPathInsideBase('', base)).to.be.false;
+      expect(isPathInsideBase(undefined, base)).to.be.false;
+    });
+  });
+
+  describe('isWellFormedJwt', () => {
+    it('accepts a structurally valid three-part token', () => {
+      expect(isWellFormedJwt('aaa.bbb.ccc')).to.be.true;
+      expect(isWellFormedJwt('eyJhbGci.eyJzdWIi.SflKxwRJ-abc_123')).to.be.true;
+    });
+
+    it('rejects tokens without exactly three parts', () => {
+      expect(isWellFormedJwt('aaa.bbb')).to.be.false;
+      expect(isWellFormedJwt('aaa.bbb.ccc.ddd')).to.be.false;
+      expect(isWellFormedJwt('notajwt')).to.be.false;
+    });
+
+    it('rejects tokens with empty or invalid segments', () => {
+      expect(isWellFormedJwt('aaa..ccc')).to.be.false;
+      expect(isWellFormedJwt('aaa.b b.ccc')).to.be.false;
+      expect(isWellFormedJwt('')).to.be.false;
+      expect(isWellFormedJwt(undefined)).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Issue (APS-19009, Critical)
`browserstack.json` `npm_dependencies` are merged into a temp `package.json` and installed via `npm install` **without `--ignore-scripts`**. A PR-supplied malicious package's `postinstall` therefore executes on the CI runner → RCE + theft of `BROWSERSTACK_ACCESS_KEY` / `GITHUB_TOKEN`.

## Fix (minimal)
- **`--ignore-scripts`** added to both `npm install` invocations — the core RCE fix (blocks lifecycle scripts). `npm_dependencies` is documented pure-JS only.
- **Validate names + version specs** before writing `package.json`: standard npm package-name regex + a semver/dist-tag-only version charset, rejecting `git+ssh://` / `file:` / path / alternate-registry specs (dependency confusion / code-exec via spec).
- **`shell:true` retained deliberately** (documented in code): the command line is fully static — dependency names live in `package.json` *data*, never on the command line, so there is **no injection surface** — and `shell:true` is required for the `>` output redirection and to invoke `npm.cmd` on Windows. Flipping to `shell:false` would risk breaking Windows for zero security gain.

## Testing
- Validation: rejects `evil; curl|sh`, `git+ssh://...`, `file:../../etc`, `$(env)`; accepts `^4.17.21`, `~2.0.0`, `13.6.0`.
- `--ignore-scripts` present in both install arg arrays; `node --check` clean.

Refs: APS-19009 (INJ-007 / INF-006)