### PR TITLE
fix(rerun): send project-relative spec paths to remote on re-run [SDK-7124]

### DIFF
--- a/bin/helpers/utils.js
+++ b/bin/helpers/utils.js
@@ -491,10 +491,20 @@ exports.setNodeVersion = (bsConfig, args) => {
 }
 
 // specs can be passed from bstack configuration file
+// True when the spec list for this run comes from BROWSERSTACK_RERUN_TESTS rather than
+// the user's config/CLI args. Shared by setUserSpecs and getNumberOfSpecFiles so the two
+// cannot drift apart — getNumberOfSpecFiles rewrites specs only for runs setUserSpecs
+// actually sourced from the re-run env.
+exports.isReRunSpecsSession = () => {
+  return o11yHelpers.isBrowserstackInfra()
+    && o11yHelpers.isTestObservabilitySession()
+    && o11yHelpers.shouldReRunObservabilityTests();
+}
+
 // specs can be passed via command line args as a string
 // command line args takes precedence over config
 exports.setUserSpecs = (bsConfig, args) => {
-  if(o11yHelpers.isBrowserstackInfra() && o11yHelpers.isTestObservabilitySession() && o11yHelpers.shouldReRunObservabilityTests()) {
+  if(this.isReRunSpecsSession()) {
     // BROWSERSTACK_RERUN_TESTS arrives comma+space separated (e.g. "a.ts, b.ts"); normalise
     // like the other spec sources below, else sanitizeSpecsPattern builds "{a.ts, b.ts}" whose
     // space-prefixed brace alternatives never match and the failed-spec filter collapses.
@@ -1232,6 +1242,16 @@ exports.getNumberOfSpecFiles = (bsConfig, args, cypressConfig, turboScaleSession
     files = files.map((x) => { return x.replaceAll("\\", "/") })
     // setting specs for turboScale as we don't have patched API for turboscale so we will rely on info from CLI
     bsConfig.run_settings.specs = files;
+  } else if (this.isReRunSpecsSession() && files.length) {
+    // BROWSERSTACK_RERUN_TESTS arrives as bare filenames ("a.ts,b.ts"). run_settings is
+    // forwarded to the remote machines verbatim, and a bare filename does not resolve
+    // against the project root there, so Cypress exits having run no spec at all. The
+    // glob above already resolved them against cypressProjectDir — persist those
+    // project-relative paths so the remote receives something it can resolve.
+    bsConfig.run_settings.specs = files
+      .map((file) => path.relative(bsConfig.run_settings.cypressProjectDir, file).replaceAll("\\", "/"))
+      .join(",");
+    logger.debug(`Re-run specs resolved to project-relative paths: ${bsConfig.run_settings.specs}`);
   }
   return files;
   } catch (err) {

--- a/test/unit/bin/helpers/utils.js
+++ b/test/unit/bin/helpers/utils.js
@@ -2327,6 +2327,76 @@ describe('utils', () => {
   });
 
   describe('getNumberOfSpecFiles', () => {
+    context('when re-running observability failed tests (SDK-7124)', () => {
+      let rerunStubs = [];
+      const specPattern = `cypress/e2e/**/*.+(${constant.specFileTypes.join('|')})`;
+
+      const stubGlob = () => {
+        const globStub = sinon.stub(glob, 'sync');
+        globStub.withArgs(specPattern).returns([
+          'cypress/e2e/FlightOffer/FO-E2E-02.ts',
+          'cypress/e2e/FlightOffer/FO-E2E-05.ts',
+          'cypress/e2e/FlightOffer/FO-E2E-09.ts',
+        ]);
+        globStub.withArgs('{FO-E2E-02.ts,FO-E2E-05.ts}').returns([
+          'cypress/e2e/FlightOffer/FO-E2E-02.ts',
+          'cypress/e2e/FlightOffer/FO-E2E-05.ts',
+        ]);
+        return globStub;
+      };
+
+      const buildConfig = (specs) => ({
+        run_settings: {
+          cypressTestSuiteType: CYPRESS_V10_AND_ABOVE_TYPE,
+          specs: specs,
+          cypressProjectDir: '/repo',
+        },
+      });
+
+      beforeEach(() => {
+        rerunStubs.push(sinon.stub(o11yHelpers, 'isBrowserstackInfra').returns(true));
+        rerunStubs.push(sinon.stub(o11yHelpers, 'isTestObservabilitySession').returns(true));
+        rerunStubs.push(sinon.stub(o11yHelpers, 'shouldReRunObservabilityTests').returns(true));
+      });
+
+      afterEach(() => {
+        rerunStubs.forEach((s) => s.restore());
+        rerunStubs = [];
+        if (glob.sync.restore) glob.sync.restore();
+      });
+
+      it('rewrites the bare rerun filenames to project-relative paths for the remote machines', () => {
+        stubGlob();
+        // shape setUserSpecs leaves behind for a rerun: bare filenames, comma separated
+        let bsConfig = buildConfig('FO-E2E-02.ts,FO-E2E-05.ts');
+
+        const result = utils.getNumberOfSpecFiles(bsConfig, {}, {});
+
+        expect(result.length).to.eql(2);
+        // run_settings is forwarded to the remote verbatim, so it must carry resolvable paths
+        expect(bsConfig.run_settings.specs).to.be.eq(
+          'cypress/e2e/FlightOffer/FO-E2E-02.ts,cypress/e2e/FlightOffer/FO-E2E-05.ts'
+        );
+      });
+
+      it('leaves specs untouched when this is not a rerun session', () => {
+        rerunStubs.forEach((s) => s.restore());
+        rerunStubs = [];
+        sinon.stub(o11yHelpers, 'isBrowserstackInfra').returns(false);
+        sinon.stub(o11yHelpers, 'isTestObservabilitySession').returns(false);
+        sinon.stub(o11yHelpers, 'shouldReRunObservabilityTests').returns(false);
+        rerunStubs.push(o11yHelpers.isBrowserstackInfra);
+        rerunStubs.push(o11yHelpers.isTestObservabilitySession);
+        rerunStubs.push(o11yHelpers.shouldReRunObservabilityTests);
+        stubGlob();
+        let bsConfig = buildConfig('FO-E2E-02.ts,FO-E2E-05.ts');
+
+        utils.getNumberOfSpecFiles(bsConfig, {}, {});
+
+        expect(bsConfig.run_settings.specs).to.be.eq('FO-E2E-02.ts,FO-E2E-05.ts');
+      });
+    });
+
     it('should return files matching with run_settings.specs and under default folder if cypress v <= 9 and no integration/testFiles patterm provided', () => {
       let globStub = sinon.stub(glob, 'sync')
       globStub.withArgs('cypress/integration/foo*.js')


### PR DESCRIPTION
## Summary

Follow-up to #1157 on the same ticket. That PR made the CLI **select** the right specs on a TRA "re-run failed tests"; this one makes the remote machines actually **run** them.

`BROWSERSTACK_RERUN_TESTS` arrives as bare filenames (`"FO-E2E-02.ts, FO-E2E-05.ts"`). `run_settings` is forwarded to the BrowserStack machines verbatim (`capabilityHelper.js` → `obj.run_settings = JSON.stringify(bsConfig.run_settings)`), and a bare filename does not resolve against the project root there — so Cypress exits having run **no spec at all**:

```
Cypress could not run any of the specs in the build since an exception occurred.
```

`getNumberOfSpecFiles` already resolves those entries against `cypressProjectDir` (it globs with `matchBase: true`, which is why the machine count is correct), but it only persisted the resolved list back to `run_settings.specs` under `turboScaleSession`. For a normal run the remote kept receiving the unresolvable basenames.

## What lands here

| File | Change |
|---|---|
| `bin/helpers/utils.js` | New `isReRunSpecsSession()` — the 3-part observability re-run predicate, now shared by `setUserSpecs` and `getNumberOfSpecFiles` so the two cannot drift apart. `getNumberOfSpecFiles` persists the already-resolved, project-relative paths to `run_settings.specs` on a re-run. |
| `test/unit/bin/helpers/utils.js` | Regression tests: the re-run case rewrites basenames to project-relative paths; a non-re-run session leaves `specs` untouched. |

Scoped deliberately: this is an `else if` on the re-run predicate, **not** a blanket write-back. A plain `--spec` glob (e.g. `cypress/tests/FlightOffer/*`) is still forwarded verbatim rather than being expanded into an explicit file list.

## Verification

Reproduced and verified on real BrowserStack builds with a 5-spec suite (3 passing / 2 failing), using the customer's command shape (`--sync --spec "cypress/tests/FlightOffer/*"`):

| Run | CLI | `BROWSERSTACK_RERUN_TESTS` | Result | Build |
|---|---|---|---|---|
| 1 | 1.36.17 | — (baseline) | 3 passed / 2 failed | `0519457f…` |
| 2 | 1.36.17 | absent | **all 5 re-ran** (the reported symptom) | `75c45973…` |
| 3, 5 | 1.36.17 | **basenames** | 2 machines picked, **0 specs executed** — deterministic 2/2 | `1e9ce9bf…`, `a6b73ce4…` |
| 4 | 1.36.17 | project-relative paths | exactly the 2 failed specs ran | `f5440dfc…` |
| **7** | **this branch** | **basenames** (identical input to 3/5) | **exactly the 2 failed specs ran, `Total tests: 2`** | `e0786caf…` |

Runs 3/5 → Run 7 is the broken→fixed transition on identical input.

## Test plan

- [x] New regression unit tests on `getNumberOfSpecFiles` — re-run path rewrites to project-relative paths; non-re-run path unchanged.
- [x] Full `test/unit/bin/helpers/utils.js` suite: **393 passing** on this branch vs **391 on a clean `master`** checkout. The 5 failing (`setLocalArgs` / `setNodeVersion` / `getVideoConfig` ×3) are pre-existing and unrelated — present on clean `master` too (verified via `git stash`).
- [x] In-process check against the real exported functions, including two control cases: a normal `--spec` glob is preserved verbatim and still matches all 9 specs; a run with no `--spec` still yields `specs: null`.
- [x] Live build with the patched CLI (Run 7 above).

## Notes / scope

- Backward compatible: only the observability re-run path is affected; normal runs and TurboScale are untouched.
- Windows-safe: separators are normalised to `/`, matching the existing TurboScale branch.
- Complements #1157 — that PR normalised the comma+space separator, this one resolves the filenames to paths. Both are needed for a re-run to scope correctly end to end.
- Related, outside this repo: for **GitHub Actions** the failed-spec env only reaches the runner if the workflow runs `browserstack/github-actions/setup-env` (v1.0.2+) with a `github-token` input — GitHub's native re-run API cannot inject env vars. That is a workflow/docs gap tracked separately on the ticket.

## Release

- [ ] minor
- [x] patch — bug fix only.

**Release notes:** Fixed BrowserStack "re-run failed tests" on Cypress running the full suite or failing with "could not run any of the specs" — the failed-spec list is now resolved to project-relative paths before it is sent to the BrowserStack machines.

Fixes SDK-7124.
