### PR TITLE
fix(o11y): batch the event flush so command-heavy specs stop hitting spec_timeout [SDK-7399]

### DIFF
--- a/bin/testObservability/cypress/index.js
+++ b/bin/testObservability/cypress/index.js
@@ -31,7 +31,6 @@ const getCircularReplacer = () => {
  * `null` is a "skip this event" sentinel — callers must NOT forward it to cy.task, because
  * the Node o11y handler expects a structured event payload, not an error stub. Skipping keeps
  * graceful degradation total: no crash, and no malformed event reaches the collector.
- *
  */
 const sanitizeForTask = (data) => {
   try {
@@ -351,18 +350,29 @@ const warnFlushFailure = (stage, err) => {
 };
 
 /*
- * [SDK-7399] These flush sites run inside mocha beforeEach/afterEach, so a failing
- * dispatch here fails the hook and mocha then SKIPS every remaining test in the spec.
- * Dispatch stays on cy.task (cy.now('task')
- * throws on Cypress 14 in every context — test body, hook and listener — so switching to
- * it silently drops all browser-side telemetry). Because cy.task enqueues, its failure
- * surfaces after this function returns and cannot be caught here; the protection is
- * therefore to never build a payload that fails — see sanitizeForTask's size cap. The
- * try/catch below remains as a backstop for anything raised synchronously while building
- * or enqueuing an event.
+ * [SDK-7399] Send the whole drain as ONE cy.task instead of one cy.task per event.
+ *
+ * Each cy.task round-trip costs roughly 0.8s on a remote terminal. Measured there, with
+ * N events queued per afterEach: N=10 -> 114s, N=100 -> 581s, N=1000 -> the session was
+ * killed. A command-heavy test queues hundreds of events, so the old per-event flush ran
+ * for minutes inside the hook, the spec exceeded spec_timeout, and every test that had not
+ * run yet was reported as SKIPPED. Nothing throws in that failure — build-info on a
+ * reproducing build shows failed:0 with the sessions killed at the timeout. Locally the
+ * same dispatch is effectively free, which is why local runs never reproduced it.
+ *
+ * Batching is what fixes it: the same 600 events sent as one call took 109s versus 581s.
+ *
+ * Dispatch deliberately stays on cy.task. cy.now('task', ...) throws on Cypress 14 in
+ * every context — test body, hook and listener — so using it stops the skipping only by
+ * never delivering anything, which silently empties the dashboard.
+ *
+ * The try/catch here is a backstop for anything raised synchronously while building or
+ * enqueuing. It cannot catch a cy.task failure, which surfaces later while the command
+ * queue drains — hence fixing the cost rather than trying to contain the symptom.
  */
-/* Keep each batch comfortably under the ~1MB per-cy.task ceiling measured on a remote
- * terminal (768KB succeeds, 1MB fails), so a large flush is split rather than dropped. */
+
+/* Split each batch under the ~1MB per-cy.task ceiling measured on a remote terminal
+ * (768KB succeeds, 1MB fails), so a large flush is split rather than lost. */
 const MAX_BATCH_CHARS = 512 * 1024;
 
 const flushEventsQueue = () => {
@@ -390,7 +400,7 @@ const flushEventsQueue = () => {
       try {
         const payload = sanitizeForTask(event.data);
         if (payload === null) {
-          warnFlushFailure(`oversized or unserializable payload for '${event.task}'`,
+          warnFlushFailure(`unserializable payload for '${event.task}'`,
             new Error('event skipped'));
           return;
         }

--- a/bin/testObservability/cypress/index.js
+++ b/bin/testObservability/cypress/index.js
@@ -339,6 +339,50 @@ Cypress.Commands.add('fatal', (message, file) => {
   });
 });
 
+/*
+ * [SDK-7399] Drain eventsQueue without ever being able to fail the customer's suite.
+ *
+ * These flush sites run inside mocha `beforeEach`/`afterEach`. Up to v1.32.8 the same
+ * events were dispatched from `Cypress.on(...)` listeners — i.e. OUTSIDE any mocha hook —
+ * and every dispatch was additionally wrapped in `.catch()`, so an instrumentation
+ * failure could not affect the run. v1.33.0 moved the dispatch INTO these hooks and
+ * dropped all error handling, which makes instrumentation errors fatal to the customer:
+ * a throw inside a hook fails that hook, and mocha then SKIPS EVERY REMAINING TEST in
+ * the suite. That is the reported symptom — tests reported as skipped that the customer
+ * never skipped.
+ *
+ * Two independent guards are required, because both failure modes were observed:
+ *   1. SYNCHRONOUS throw — `cy.task`/`cy.now` can throw straight out of the call
+ *      (`TypeError: Cannot read properties of null (reading 'get')` raised inside
+ *      Cypress' own `runPrivilegedCommand`). A promise `.catch()` never runs for this,
+ *      so a real try/catch is needed.
+ *   2. ASYNCHRONOUS rejection — handled by the promise `.catch()`.
+ *
+ * `cy.now('task', ...)` is used rather than `cy.task(...)`: `cy.task` enqueues a Cypress
+ * command, so a failure surfaces later while the queue drains and fails the hook no
+ * matter what guard wraps the enqueue call. `cy.now` executes immediately and returns a
+ * promise, which is exactly what v1.32.8 did and is therefore containable here.
+ */
+const flushEventsQueue = () => {
+  try {
+    const queued = eventsQueue;
+    eventsQueue = [];
+    queued.forEach(event => {
+      try {
+        const payload = sanitizeForTask(event.data);
+        if (payload === null) return;
+        const result = cy.now('task', event.task, payload, event.options);
+        if (result && typeof result.catch === 'function') result.catch(() => {});
+      } catch (e) {
+        /* one bad event must not stop the remaining events, and must not fail the hook */
+      }
+    });
+  } catch (e) {
+    /* instrumentation must never break the customer's test run */
+    eventsQueue = [];
+  }
+};
+
 beforeEach(() => {
   /* browserstack internal helper hook */
 
@@ -346,13 +390,7 @@ beforeEach(() => {
     return;
   }
 
-  if (eventsQueue.length > 0) {
-    eventsQueue.forEach(event => {
-      const payload = sanitizeForTask(event.data);
-      if (payload !== null) cy.task(event.task, payload, event.options);
-    });
-  }
-  eventsQueue = [];
+  flushEventsQueue();
   testRunStarted = true;
 });
 
@@ -362,13 +400,6 @@ afterEach(function() {
     return;
   }
 
-  if (eventsQueue.length > 0) {
-    eventsQueue.forEach(event => {
-      const payload = sanitizeForTask(event.data);
-      if (payload !== null) cy.task(event.task, payload, event.options);
-    });
-  }
-  
-  eventsQueue = [];
+  flushEventsQueue();
   testRunStarted = false;
 });

--- a/bin/testObservability/cypress/index.js
+++ b/bin/testObservability/cypress/index.js
@@ -31,8 +31,7 @@ const getCircularReplacer = () => {
  * `null` is a "skip this event" sentinel — callers must NOT forward it to cy.task, because
  * the Node o11y handler expects a structured event payload, not an error stub. Skipping keeps
  * graceful degradation total: no crash, and no malformed event reaches the collector.
- */
-/*
+ *
  * [SDK-7399] An oversized cy.task payload fails the command, and because the flush runs
  * inside a mocha hook that failure skips every remaining test in the spec. Measured on a
  * remote Windows terminal: a single 64KB payload succeeds, 1MB and 8MB fail; event COUNT
@@ -84,7 +83,9 @@ const shouldSkipCommand = (command) => {
   if (!Cypress.env('BROWSERSTACK_O11Y_LOGS')) {
     return true;
   }
-  return command.attributes.name == 'log' || (command.attributes.name == 'task' && (['test_observability_platform_details', 'test_observability_step', 'test_observability_command', 'browserstack_log', 'test_observability_log'].some(event => command.attributes.args.includes(event))));
+  /* test_observability_batch must be filtered here too, or each batch dispatch would
+   * itself be captured as a command event and refill the queue. [SDK-7399] */
+  return command.attributes.name == 'log' || (command.attributes.name == 'task' && (['test_observability_platform_details', 'test_observability_step', 'test_observability_command', 'test_observability_batch', 'browserstack_log', 'test_observability_log'].some(event => command.attributes.args.includes(event))));
 }
 
 Cypress.on('log:changed', (attrs) => {
@@ -384,7 +385,7 @@ const warnFlushFailure = (stage, err) => {
 /*
  * [SDK-7399] These flush sites run inside mocha beforeEach/afterEach, so a failing
  * dispatch here fails the hook and mocha then SKIPS every remaining test in the spec.
- * Dispatch stays on cy.task: it is the only form that actually delivers (cy.now('task')
+ * Dispatch stays on cy.task (cy.now('task')
  * throws on Cypress 14 in every context — test body, hook and listener — so switching to
  * it silently drops all browser-side telemetry). Because cy.task enqueues, its failure
  * surfaces after this function returns and cannot be caught here; the protection is
@@ -392,10 +393,31 @@ const warnFlushFailure = (stage, err) => {
  * try/catch below remains as a backstop for anything raised synchronously while building
  * or enqueuing an event.
  */
+/* Keep each batch comfortably under the ~1MB per-cy.task ceiling measured on a remote
+ * terminal (768KB succeeds, 1MB fails), so a large flush is split rather than dropped. */
+const MAX_BATCH_CHARS = 512 * 1024;
+
 const flushEventsQueue = () => {
   try {
     const queued = eventsQueue;
     eventsQueue = []; /* cleared before dispatch so a throw cannot replay these events */
+    if (queued.length === 0) return;
+
+    let batch = [];
+    let batchChars = 0;
+
+    const sendBatch = () => {
+      if (batch.length === 0) return;
+      const toSend = batch;
+      batch = [];
+      batchChars = 0;
+      try {
+        cy.task('test_observability_batch', toSend, { log: false });
+      } catch (e) {
+        warnFlushFailure(`batch dispatch of ${toSend.length} event(s)`, e);
+      }
+    };
+
     queued.forEach(event => {
       try {
         const payload = sanitizeForTask(event.data);
@@ -404,11 +426,16 @@ const flushEventsQueue = () => {
             new Error('event skipped'));
           return;
         }
-        cy.task(event.task, payload, event.options);
+        const size = JSON.stringify(payload).length;
+        if (batchChars + size > MAX_BATCH_CHARS) sendBatch();
+        batch.push({ task: event.task, data: payload });
+        batchChars += size;
       } catch (e) {
-        warnFlushFailure(`dispatch of '${event.task}'`, e); /* skip one event, not the rest */
+        warnFlushFailure(`preparing '${event.task}'`, e); /* skip one event, not the rest */
       }
     });
+
+    sendBatch();
   } catch (e) {
     warnFlushFailure('queue flush', e);
     eventsQueue = [];

--- a/bin/testObservability/cypress/index.js
+++ b/bin/testObservability/cypress/index.js
@@ -395,7 +395,7 @@ const flushEventsQueue = () => {
         }
         const size = JSON.stringify(payload).length;
         if (size > MAX_EVENT_CHARS) {
-          /* unsendable at any size; the per-event flush could not deliver it either */
+          /* past the largest size measured to send; 768KB-1MB is untested, so skip */
           warnFlushFailure(`event too large to send for '${event.task}' (${size} chars)`,
             new Error('event skipped'));
           return;

--- a/bin/testObservability/cypress/index.js
+++ b/bin/testObservability/cypress/index.js
@@ -363,6 +363,19 @@ Cypress.Commands.add('fatal', (message, file) => {
  * matter what guard wraps the enqueue call. `cy.now` executes immediately and returns a
  * promise, which is exactly what v1.32.8 did and is therefore containable here.
  */
+/*
+ * Every suppression below must leave a trace. A dropped event is invisible to the
+ * customer's run by design, but it must not be invisible to us — otherwise a future
+ * flush failure only shows up as data quietly missing from the dashboard. `console.warn`
+ * is used deliberately rather than `browserStackLog`/`cy.task`: routing a diagnostic
+ * through another Cypress command would reintroduce exactly the failure being contained.
+ */
+const warnFlushFailure = (stage, err) => {
+  try {
+    console.warn(`BrowserStack Test Observability: suppressed ${stage} error, event(s) dropped: ${err && err.message ? err.message : err}`);
+  } catch (e) { /* logging must never throw either */ }
+};
+
 const flushEventsQueue = () => {
   try {
     const queued = eventsQueue;
@@ -372,13 +385,17 @@ const flushEventsQueue = () => {
         const payload = sanitizeForTask(event.data);
         if (payload === null) return;
         const result = cy.now('task', event.task, payload, event.options);
-        if (result && typeof result.catch === 'function') result.catch(() => {});
+        if (result && typeof result.catch === 'function') {
+          result.catch(err => warnFlushFailure(`async dispatch of '${event.task}'`, err));
+        }
       } catch (e) {
         /* one bad event must not stop the remaining events, and must not fail the hook */
+        warnFlushFailure(`dispatch of '${event.task}'`, e);
       }
     });
   } catch (e) {
     /* instrumentation must never break the customer's test run */
+    warnFlushFailure('queue flush', e);
     eventsQueue = [];
   }
 };

--- a/bin/testObservability/cypress/index.js
+++ b/bin/testObservability/cypress/index.js
@@ -50,8 +50,7 @@ const shouldSkipCommand = (command) => {
   if (!Cypress.env('BROWSERSTACK_O11Y_LOGS')) {
     return true;
   }
-  /* test_observability_batch must be filtered here too, or each batch dispatch would
-   * itself be captured as a command event and refill the queue. [SDK-7399] */
+  /* the batch task is filtered too, else each dispatch refills the queue */
   return command.attributes.name == 'log' || (command.attributes.name == 'task' && (['test_observability_platform_details', 'test_observability_step', 'test_observability_command', 'test_observability_batch', 'browserstack_log', 'test_observability_log'].some(event => command.attributes.args.includes(event))));
 }
 
@@ -341,8 +340,7 @@ Cypress.Commands.add('fatal', (message, file) => {
   });
 });
 
-/* console.warn, not browserStackLog/cy.task — routing a diagnostic through another
- * Cypress command would reintroduce the failure this boundary contains. [SDK-7399] */
+/* console.warn, not cy.task — a diagnostic must not use the mechanism it reports on */
 const warnFlushFailure = (stage, err) => {
   try {
     console.warn(`BrowserStack Test Observability: suppressed ${stage} error, event(s) dropped: ${err && err.message ? err.message : err}`);
@@ -350,30 +348,20 @@ const warnFlushFailure = (stage, err) => {
 };
 
 /*
- * [SDK-7399] Send the whole drain as ONE cy.task instead of one cy.task per event.
- *
- * Each cy.task round-trip costs roughly 0.8s on a remote terminal. Measured there, with
- * N events queued per afterEach: N=10 -> 114s, N=100 -> 581s, N=1000 -> the session was
- * killed. A command-heavy test queues hundreds of events, so the old per-event flush ran
- * for minutes inside the hook, the spec exceeded spec_timeout, and every test that had not
- * run yet was reported as SKIPPED. Nothing throws in that failure — build-info on a
- * reproducing build shows failed:0 with the sessions killed at the timeout. Locally the
- * same dispatch is effectively free, which is why local runs never reproduced it.
- *
- * Batching is what fixes it: the same 600 events sent as one call took 109s versus 581s.
- *
- * Dispatch deliberately stays on cy.task. cy.now('task', ...) throws on Cypress 14 in
- * every context — test body, hook and listener — so using it stops the skipping only by
- * never delivering anything, which silently empties the dashboard.
- *
- * The try/catch here is a backstop for anything raised synchronously while building or
- * enqueuing. It cannot catch a cy.task failure, which surfaces later while the command
- * queue drains — hence fixing the cost rather than trying to contain the symptom.
+ * [SDK-7399] One cy.task per drain, not per event. Each round-trip costs ~0.8s on a
+ * remote terminal, so a command-heavy spec spent minutes in afterEach, exceeded
+ * spec_timeout and was killed — unrun tests then reported as skipped, with nothing
+ * thrown. 600 events: 581s as 600 calls, 109s as one.
+ * Stays on cy.task: cy.now('task') throws on Cypress 14, so it would "fix" this by
+ * delivering nothing. The try/catch is only a backstop for synchronous throws — a
+ * cy.task failure surfaces later, while the command queue drains.
  */
 
-/* Split each batch under the ~1MB per-cy.task ceiling measured on a remote terminal
- * (768KB succeeds, 1MB fails), so a large flush is split rather than lost. */
+/* Remote terminal: a single cy.task payload of 768KB succeeds, 1MB fails.
+ * Split well under that; drop only what cannot be sent at all. The two must stay
+ * distinct — an event between them still sends on its own. */
 const MAX_BATCH_CHARS = 512 * 1024;
+const MAX_EVENT_CHARS = 768 * 1024;
 
 const flushEventsQueue = () => {
   try {
@@ -390,6 +378,7 @@ const flushEventsQueue = () => {
       batch = [];
       batchChars = 0;
       try {
+        /* every push site uses { log: false }, so per-event options are not forwarded */
         cy.task('test_observability_batch', toSend, { log: false });
       } catch (e) {
         warnFlushFailure(`batch dispatch of ${toSend.length} event(s)`, e);
@@ -405,18 +394,17 @@ const flushEventsQueue = () => {
           return;
         }
         const size = JSON.stringify(payload).length;
-        if (size > MAX_BATCH_CHARS) {
-          /* A single event this large cannot be sent under the ~1MB per-cy.task ceiling
-           * measured on a remote terminal (768KB passes, 1MB fails). Dropping it is not a
-           * fidelity regression: before batching it was dispatched alone and would have
-           * failed the command anyway. Nothing smaller is altered or truncated. */
+        if (size > MAX_EVENT_CHARS) {
+          /* unsendable at any size; the per-event flush could not deliver it either */
           warnFlushFailure(`event too large to send for '${event.task}' (${size} chars)`,
             new Error('event skipped'));
           return;
         }
-        if (batchChars + size > MAX_BATCH_CHARS) sendBatch();
+        /* oversized-but-sendable: let it travel alone */
+        if (batch.length > 0 && batchChars + size > MAX_BATCH_CHARS) sendBatch();
         batch.push({ task: event.task, data: payload });
         batchChars += size;
+        if (batchChars >= MAX_BATCH_CHARS) sendBatch();
       } catch (e) {
         warnFlushFailure(`preparing '${event.task}'`, e); /* skip one event, not the rest */
       }

--- a/bin/testObservability/cypress/index.js
+++ b/bin/testObservability/cypress/index.js
@@ -32,42 +32,10 @@ const getCircularReplacer = () => {
  * the Node o11y handler expects a structured event payload, not an error stub. Skipping keeps
  * graceful degradation total: no crash, and no malformed event reaches the collector.
  *
- * [SDK-7399] An oversized cy.task payload fails the command, and because the flush runs
- * inside a mocha hook that failure skips every remaining test in the spec. Measured on a
- * remote Windows terminal: a single 64KB payload succeeds, 1MB and 8MB fail; event COUNT
- * is not the problem (1000 small events succeed). Command args are the realistic source
- * of bulk, so cap individual strings first and only drop the event if it is still too
- * large. Preventing the oversized dispatch is what keeps the customer's suite intact —
- * containment alone cannot, since the failure surfaces after the enqueue call returns.
  */
-const MAX_TASK_PAYLOAD_CHARS = 128 * 1024;
-const MAX_STRING_CHARS = 8 * 1024;
-const TRUNCATION_MARKER = '…[browserstack: truncated]';
-
-const getTruncatingReplacer = () => {
-  const seen = new WeakSet();
-  return (key, value) => {
-    if (typeof value === 'string' && value.length > MAX_STRING_CHARS) {
-      return value.slice(0, MAX_STRING_CHARS) + TRUNCATION_MARKER;
-    }
-    if (typeof value === 'object' && value !== null) {
-      if (seen.has(value)) return '[Circular]';
-      seen.add(value);
-    }
-    return value;
-  };
-};
-
-/* Returns a JSON-safe plain object small enough to ship, or `null` to skip the event. */
 const sanitizeForTask = (data) => {
   try {
-    let json = JSON.stringify(data, getCircularReplacer());
-    if (json === undefined) return null;
-    if (json.length > MAX_TASK_PAYLOAD_CHARS) {
-      json = JSON.stringify(data, getTruncatingReplacer());
-      if (json === undefined || json.length > MAX_TASK_PAYLOAD_CHARS) return null;
-    }
-    return JSON.parse(json);
+    return JSON.parse(JSON.stringify(data, getCircularReplacer()));
   } catch (e) {
     return null;
   }
@@ -427,6 +395,15 @@ const flushEventsQueue = () => {
           return;
         }
         const size = JSON.stringify(payload).length;
+        if (size > MAX_BATCH_CHARS) {
+          /* A single event this large cannot be sent under the ~1MB per-cy.task ceiling
+           * measured on a remote terminal (768KB passes, 1MB fails). Dropping it is not a
+           * fidelity regression: before batching it was dispatched alone and would have
+           * failed the command anyway. Nothing smaller is altered or truncated. */
+          warnFlushFailure(`event too large to send for '${event.task}' (${size} chars)`,
+            new Error('event skipped'));
+          return;
+        }
         if (batchChars + size > MAX_BATCH_CHARS) sendBatch();
         batch.push({ task: event.task, data: payload });
         batchChars += size;

--- a/bin/testObservability/cypress/index.js
+++ b/bin/testObservability/cypress/index.js
@@ -339,47 +339,28 @@ Cypress.Commands.add('fatal', (message, file) => {
   });
 });
 
-/*
- * [SDK-7399] Drain eventsQueue without ever being able to fail the customer's suite.
- *
- * These flush sites run inside mocha `beforeEach`/`afterEach`. Up to v1.32.8 the same
- * events were dispatched from `Cypress.on(...)` listeners — i.e. OUTSIDE any mocha hook —
- * and every dispatch was additionally wrapped in `.catch()`, so an instrumentation
- * failure could not affect the run. v1.33.0 moved the dispatch INTO these hooks and
- * dropped all error handling, which makes instrumentation errors fatal to the customer:
- * a throw inside a hook fails that hook, and mocha then SKIPS EVERY REMAINING TEST in
- * the suite. That is the reported symptom — tests reported as skipped that the customer
- * never skipped.
- *
- * Two independent guards are required, because both failure modes were observed:
- *   1. SYNCHRONOUS throw — `cy.task`/`cy.now` can throw straight out of the call
- *      (`TypeError: Cannot read properties of null (reading 'get')` raised inside
- *      Cypress' own `runPrivilegedCommand`). A promise `.catch()` never runs for this,
- *      so a real try/catch is needed.
- *   2. ASYNCHRONOUS rejection — handled by the promise `.catch()`.
- *
- * `cy.now('task', ...)` is used rather than `cy.task(...)`: `cy.task` enqueues a Cypress
- * command, so a failure surfaces later while the queue drains and fails the hook no
- * matter what guard wraps the enqueue call. `cy.now` executes immediately and returns a
- * promise, which is exactly what v1.32.8 did and is therefore containable here.
- */
-/*
- * Every suppression below must leave a trace. A dropped event is invisible to the
- * customer's run by design, but it must not be invisible to us — otherwise a future
- * flush failure only shows up as data quietly missing from the dashboard. `console.warn`
- * is used deliberately rather than `browserStackLog`/`cy.task`: routing a diagnostic
- * through another Cypress command would reintroduce exactly the failure being contained.
- */
+/* console.warn, not browserStackLog/cy.task — routing a diagnostic through another
+ * Cypress command would reintroduce the failure this boundary contains. [SDK-7399] */
 const warnFlushFailure = (stage, err) => {
   try {
     console.warn(`BrowserStack Test Observability: suppressed ${stage} error, event(s) dropped: ${err && err.message ? err.message : err}`);
   } catch (e) { /* logging must never throw either */ }
 };
 
+/*
+ * [SDK-7399] These flush sites run inside mocha beforeEach/afterEach, so a throw here
+ * fails the hook and mocha then SKIPS every remaining test in the spec. Before v1.33.0
+ * the same events were dispatched from Cypress.on(...) listeners — outside any hook,
+ * each wrapped in .catch() — so a failure was harmless. Keep this boundary intact:
+ *   - cy.now, not cy.task: cy.task enqueues, so its failure surfaces later during queue
+ *     drain and fails the hook regardless of any guard here. cy.now runs immediately.
+ *   - try/catch AND .catch: cy.now can throw synchronously out of Cypress'
+ *     runPrivilegedCommand, which a promise .catch() never sees.
+ */
 const flushEventsQueue = () => {
   try {
     const queued = eventsQueue;
-    eventsQueue = [];
+    eventsQueue = []; /* cleared before dispatch so a throw cannot replay these events */
     queued.forEach(event => {
       try {
         const payload = sanitizeForTask(event.data);
@@ -389,12 +370,10 @@ const flushEventsQueue = () => {
           result.catch(err => warnFlushFailure(`async dispatch of '${event.task}'`, err));
         }
       } catch (e) {
-        /* one bad event must not stop the remaining events, and must not fail the hook */
-        warnFlushFailure(`dispatch of '${event.task}'`, e);
+        warnFlushFailure(`dispatch of '${event.task}'`, e); /* skip one event, not the rest */
       }
     });
   } catch (e) {
-    /* instrumentation must never break the customer's test run */
     warnFlushFailure('queue flush', e);
     eventsQueue = [];
   }

--- a/bin/testObservability/cypress/index.js
+++ b/bin/testObservability/cypress/index.js
@@ -32,9 +32,43 @@ const getCircularReplacer = () => {
  * the Node o11y handler expects a structured event payload, not an error stub. Skipping keeps
  * graceful degradation total: no crash, and no malformed event reaches the collector.
  */
+/*
+ * [SDK-7399] An oversized cy.task payload fails the command, and because the flush runs
+ * inside a mocha hook that failure skips every remaining test in the spec. Measured on a
+ * remote Windows terminal: a single 64KB payload succeeds, 1MB and 8MB fail; event COUNT
+ * is not the problem (1000 small events succeed). Command args are the realistic source
+ * of bulk, so cap individual strings first and only drop the event if it is still too
+ * large. Preventing the oversized dispatch is what keeps the customer's suite intact —
+ * containment alone cannot, since the failure surfaces after the enqueue call returns.
+ */
+const MAX_TASK_PAYLOAD_CHARS = 128 * 1024;
+const MAX_STRING_CHARS = 8 * 1024;
+const TRUNCATION_MARKER = '…[browserstack: truncated]';
+
+const getTruncatingReplacer = () => {
+  const seen = new WeakSet();
+  return (key, value) => {
+    if (typeof value === 'string' && value.length > MAX_STRING_CHARS) {
+      return value.slice(0, MAX_STRING_CHARS) + TRUNCATION_MARKER;
+    }
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) return '[Circular]';
+      seen.add(value);
+    }
+    return value;
+  };
+};
+
+/* Returns a JSON-safe plain object small enough to ship, or `null` to skip the event. */
 const sanitizeForTask = (data) => {
   try {
-    return JSON.parse(JSON.stringify(data, getCircularReplacer()));
+    let json = JSON.stringify(data, getCircularReplacer());
+    if (json === undefined) return null;
+    if (json.length > MAX_TASK_PAYLOAD_CHARS) {
+      json = JSON.stringify(data, getTruncatingReplacer());
+      if (json === undefined || json.length > MAX_TASK_PAYLOAD_CHARS) return null;
+    }
+    return JSON.parse(json);
   } catch (e) {
     return null;
   }
@@ -348,14 +382,15 @@ const warnFlushFailure = (stage, err) => {
 };
 
 /*
- * [SDK-7399] These flush sites run inside mocha beforeEach/afterEach, so a throw here
- * fails the hook and mocha then SKIPS every remaining test in the spec. Before v1.33.0
- * the same events were dispatched from Cypress.on(...) listeners — outside any hook,
- * each wrapped in .catch() — so a failure was harmless. Keep this boundary intact:
- *   - cy.now, not cy.task: cy.task enqueues, so its failure surfaces later during queue
- *     drain and fails the hook regardless of any guard here. cy.now runs immediately.
- *   - try/catch AND .catch: cy.now can throw synchronously out of Cypress'
- *     runPrivilegedCommand, which a promise .catch() never sees.
+ * [SDK-7399] These flush sites run inside mocha beforeEach/afterEach, so a failing
+ * dispatch here fails the hook and mocha then SKIPS every remaining test in the spec.
+ * Dispatch stays on cy.task: it is the only form that actually delivers (cy.now('task')
+ * throws on Cypress 14 in every context — test body, hook and listener — so switching to
+ * it silently drops all browser-side telemetry). Because cy.task enqueues, its failure
+ * surfaces after this function returns and cannot be caught here; the protection is
+ * therefore to never build a payload that fails — see sanitizeForTask's size cap. The
+ * try/catch below remains as a backstop for anything raised synchronously while building
+ * or enqueuing an event.
  */
 const flushEventsQueue = () => {
   try {
@@ -364,11 +399,12 @@ const flushEventsQueue = () => {
     queued.forEach(event => {
       try {
         const payload = sanitizeForTask(event.data);
-        if (payload === null) return;
-        const result = cy.now('task', event.task, payload, event.options);
-        if (result && typeof result.catch === 'function') {
-          result.catch(err => warnFlushFailure(`async dispatch of '${event.task}'`, err));
+        if (payload === null) {
+          warnFlushFailure(`oversized or unserializable payload for '${event.task}'`,
+            new Error('event skipped'));
+          return;
         }
+        cy.task(event.task, payload, event.options);
       } catch (e) {
         warnFlushFailure(`dispatch of '${event.task}'`, e); /* skip one event, not the rest */
       }

--- a/bin/testObservability/plugin/index.js
+++ b/bin/testObservability/plugin/index.js
@@ -11,6 +11,13 @@ const browserstackTestObservabilityPlugin = (on, config, callbacks) => {
 
   connectIPCClient(config);
 
+  const IPC_EVENT_FOR_TASK = {
+    test_observability_log: IPC_EVENTS.LOG,
+    test_observability_command: IPC_EVENTS.COMMAND,
+    test_observability_platform_details: IPC_EVENTS.PLATFORM_DETAILS,
+    test_observability_step: IPC_EVENTS.CUCUMBER,
+  };
+
   on('task', {
     test_observability_log(log) {
       ipc.of.browserstackTestObservability.emit(IPC_EVENTS.LOG, log);
@@ -26,6 +33,29 @@ const browserstackTestObservabilityPlugin = (on, config, callbacks) => {
     },
     test_observability_step(log) {
       ipc.of.browserstackTestObservability.emit(IPC_EVENTS.CUCUMBER, log);
+      return null;
+    },
+    /*
+     * [SDK-7399] Accepts a whole flush as ONE task so the browser side issues one
+     * Cypress command per flush instead of one per event. Each cy.task round-trip costs
+     * roughly 0.8s on a remote terminal, so a command-heavy test used to spend minutes
+     * in its afterEach and the spec was killed at spec_timeout, reporting every test that
+     * had not run yet as skipped. Measured: 600 events as 600 calls = 581s; the same 600
+     * events as 1 call = 109s, i.e. baseline.
+     * Fans out to exactly the same IPC events as the individual tasks above, which stay
+     * registered for backward compatibility.
+     */
+    test_observability_batch(events) {
+      if (!Array.isArray(events)) return null;
+      events.forEach((event) => {
+        try {
+          const ipcEvent = event && IPC_EVENT_FOR_TASK[event.task];
+          if (!ipcEvent) return;
+          ipc.of.browserstackTestObservability.emit(ipcEvent, event.data);
+        } catch (e) {
+          /* one malformed event must not drop the rest of the batch */
+        }
+      });
       return null;
     }
   });

--- a/bin/testObservability/plugin/index.js
+++ b/bin/testObservability/plugin/index.js
@@ -35,16 +35,8 @@ const browserstackTestObservabilityPlugin = (on, config, callbacks) => {
       ipc.of.browserstackTestObservability.emit(IPC_EVENTS.CUCUMBER, log);
       return null;
     },
-    /*
-     * [SDK-7399] Accepts a whole flush as ONE task so the browser side issues one
-     * Cypress command per flush instead of one per event. Each cy.task round-trip costs
-     * roughly 0.8s on a remote terminal, so a command-heavy test used to spend minutes
-     * in its afterEach and the spec was killed at spec_timeout, reporting every test that
-     * had not run yet as skipped. Measured: 600 events as 600 calls = 581s; the same 600
-     * events as 1 call = 109s, i.e. baseline.
-     * Fans out to exactly the same IPC events as the individual tasks above, which stay
-     * registered for backward compatibility.
-     */
+    /* [SDK-7399] One task per flush instead of one per event — see cypress/index.js.
+     * Fans out to the same IPC events; the per-event tasks stay for back-compat. */
     test_observability_batch(events) {
       if (!Array.isArray(events)) return null;
       events.forEach((event) => {
@@ -53,7 +45,7 @@ const browserstackTestObservabilityPlugin = (on, config, callbacks) => {
           if (!ipcEvent) return;
           ipc.of.browserstackTestObservability.emit(ipcEvent, event.data);
         } catch (e) {
-          /* one malformed event must not drop the rest of the batch */
+          /* one bad entry must not drop the rest */
         }
       });
       return null;

--- a/test/unit/bin/testObservability/batchFlush.js
+++ b/test/unit/bin/testObservability/batchFlush.js
@@ -1,0 +1,85 @@
+'use strict';
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+// Regression guard for SDK-7399. The flush used to issue one cy.task per queued event,
+// and each round-trip costs ~0.8s on a remote terminal, so a command-heavy spec spent
+// minutes in afterEach, exceeded spec_timeout and was killed — every test that had not
+// run yet was then reported as skipped. Nothing threw, so a passing spec alone cannot
+// distinguish "delivered" from "silently dropped"; these tests pin the fan-out instead.
+describe('SDK-7399 batched observability flush', () => {
+  let emit, ipcStub, tasks, plugin;
+
+  beforeEach(() => {
+    emit = sinon.stub();
+    ipcStub = { of: { browserstackTestObservability: { emit } } };
+    plugin = proxyquire('../../../../bin/testObservability/plugin', {
+      'node-ipc': ipcStub,
+      './ipcClient': { connectIPCClient: () => {} },
+    });
+    tasks = null;
+    const on = (name, handlers) => { if (name === 'task') tasks = handlers; };
+    plugin(on, { env: {} });
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('registers the batch task alongside the per-event tasks', () => {
+    expect(tasks).to.have.property('test_observability_batch');
+    // per-event tasks must stay registered: an older browser bundle may still call them
+    expect(tasks).to.have.property('test_observability_log');
+    expect(tasks).to.have.property('test_observability_command');
+    expect(tasks).to.have.property('test_observability_platform_details');
+    expect(tasks).to.have.property('test_observability_step');
+  });
+
+  it('fans every queued task type out to its own IPC event, in order', () => {
+    tasks.test_observability_batch([
+      { task: 'test_observability_log', data: { m: 1 } },
+      { task: 'test_observability_command', data: { m: 2 } },
+      { task: 'test_observability_platform_details', data: { m: 3 } },
+      { task: 'test_observability_step', data: { m: 4 } },
+    ]);
+
+    expect(emit.callCount).to.equal(4);
+    expect(emit.getCalls().map(c => c.args[1].m)).to.deep.equal([1, 2, 3, 4]);
+    // four distinct IPC events, i.e. no type collapsed onto another
+    expect(new Set(emit.getCalls().map(c => c.args[0])).size).to.equal(4);
+  });
+
+  it('emits one IPC event per entry for a large batch', () => {
+    const batch = [];
+    for (let i = 0; i < 600; i++) {
+      batch.push({ task: 'test_observability_log', data: { i } });
+    }
+    tasks.test_observability_batch(batch);
+    expect(emit.callCount).to.equal(600);
+  });
+
+  it('skips an unknown task name but still delivers the rest of the batch', () => {
+    tasks.test_observability_batch([
+      { task: 'not_a_real_task', data: { m: 'x' } },
+      { task: 'test_observability_log', data: { m: 'kept' } },
+    ]);
+    expect(emit.callCount).to.equal(1);
+    expect(emit.firstCall.args[1].m).to.equal('kept');
+  });
+
+  it('never throws on malformed input', () => {
+    expect(() => tasks.test_observability_batch(undefined)).to.not.throw();
+    expect(() => tasks.test_observability_batch({})).to.not.throw();
+    expect(() => tasks.test_observability_batch([null, undefined, 1, 'x'])).to.not.throw();
+    expect(emit.callCount).to.equal(0);
+  });
+
+  it('one failing emit does not drop the remaining entries', () => {
+    emit.onFirstCall().throws(new Error('ipc down'));
+    tasks.test_observability_batch([
+      { task: 'test_observability_log', data: { m: 1 } },
+      { task: 'test_observability_log', data: { m: 2 } },
+    ]);
+    expect(emit.callCount).to.equal(2);
+  });
+});

--- a/test/unit/bin/testObservability/batchThresholds.js
+++ b/test/unit/bin/testObservability/batchThresholds.js
@@ -1,0 +1,121 @@
+'use strict';
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+
+// Guards the threshold arithmetic in bin/testObservability/cypress/index.js.
+// SDK-7399 review finding: the batch-split figure (512KB) had been reused as the
+// single-event drop ceiling, so events in the 512-768KB band — which a single cy.task
+// was measured to carry — were silently discarded. These cases pin the split, the
+// oversized-but-sendable path, and the drop boundary.
+describe('SDK-7399 flush thresholds', () => {
+  const KB = 1024;
+  let taskSpy, afterEachCb, commandStartCb;
+
+  // The browser-side file registers listeners and hooks at require time, so the Cypress
+  // globals have to exist first. Capture the pieces the flush needs.
+  const loadBrowserSide = () => {
+    const listeners = {};
+    taskSpy = sinon.stub().returns(undefined);
+
+    global.cy = { task: taskSpy, now: sinon.stub() };
+    global.Cypress = {
+      on: (evt, cb) => { listeners[evt] = cb; },
+      env: (k) => (k === 'BROWSERSTACK_O11Y_LOGS' ? 'true' : undefined),
+      Commands: { add: () => {}, overwrite: () => {} },
+      browser: { name: 'chrome', majorVersion: '136' },
+      platform: 'win32',
+      version: '14.3.3',
+      mocha: { getRunner: () => ({ suite: { ctx: { currentTest: { title: 't' } } } }) },
+    };
+    global.beforeEach = () => {};
+    global.afterEach = (cb) => { afterEachCb = cb; };
+
+    delete require.cache[require.resolve('../../../../bin/testObservability/cypress')];
+    require('../../../../bin/testObservability/cypress');
+    commandStartCb = listeners['command:start'];
+  };
+
+  // One queued event whose serialized payload is ~sizeKB, via a command arg.
+  const queueEventOfSize = (sizeKB) => {
+    commandStartCb({ attributes: { id: 'c1', name: 'type', args: ['x'.repeat(sizeKB * KB)] } });
+  };
+
+  beforeEach(loadBrowserSide);
+
+  afterEach(() => {
+    sinon.restore();
+    delete global.cy; delete global.Cypress;
+    delete global.beforeEach; delete global.afterEach;
+  });
+
+  const batchesSent = () =>
+    taskSpy.getCalls()
+      .filter(c => c.args[0] === 'test_observability_batch')
+      .map(c => c.args[1]);
+
+  it('sends small events together in a single batch', () => {
+    queueEventOfSize(1);
+    queueEventOfSize(1);
+    afterEachCb();
+
+    const batches = batchesSent();
+    expect(batches.length).to.equal(1);
+    expect(batches[0].length).to.be.greaterThan(1);
+  });
+
+  it('dispatches a 600KB event alone rather than dropping it (the regression)', () => {
+    // command:start queues two events: the command itself, plus small platform details —
+    // so the big one is expected in a batch of its own, with the small one following.
+    queueEventOfSize(600);
+    afterEachCb();
+
+    const batches = batchesSent();
+    const carrying = batches.filter(b =>
+      b.some(e => JSON.stringify(e.data).length > 512 * KB));
+    expect(carrying.length, 'the 512-768KB band must still be delivered').to.equal(1);
+    expect(carrying[0].length, 'oversized-but-sendable event travels alone').to.equal(1);
+  });
+
+  it('keeps a 600KB event out of the batch holding the small ones', () => {
+    queueEventOfSize(1);
+    queueEventOfSize(600);
+    afterEachCb();
+
+    const batches = batchesSent();
+    expect(batches.length).to.be.greaterThan(1);
+    batches.forEach(b => {
+      const chars = b.reduce((n, e) => n + JSON.stringify(e.data).length, 0);
+      // a multi-event batch stays under the split figure; a lone event may exceed it
+      if (b.length > 1) expect(chars).to.be.at.most(512 * KB);
+    });
+  });
+
+  it('skips an event past the largest measured-safe size', () => {
+    queueEventOfSize(900);
+    afterEachCb();
+
+    batchesSent().forEach(b => {
+      b.forEach(e => {
+        expect(JSON.stringify(e.data).length).to.be.at.most(768 * KB);
+      });
+    });
+  });
+
+  it('never assembles a multi-event batch beyond the split figure', () => {
+    for (let i = 0; i < 12; i++) queueEventOfSize(64);
+    afterEachCb();
+
+    batchesSent().forEach(b => {
+      if (b.length > 1) {
+        const chars = b.reduce((n, e) => n + JSON.stringify(e.data).length, 0);
+        expect(chars).to.be.at.most(512 * KB);
+      }
+    });
+  });
+
+  it('sends nothing when the queue is empty', () => {
+    afterEachCb();
+    expect(batchesSent().length).to.equal(0);
+  });
+});


### PR DESCRIPTION
## What is this about?

Customers on `1.35.x` / `1.36.x` see a large share of their tests reported as **skipped**; the same suite on `1.32.8` is clean (SDK-7399: ~113 of ~525 skipped on 1.36.18 vs 4 on 1.32.8).

**The tests are not skipped by mocha and nothing throws — the spec is killed at `spec_timeout` and every test that has not run yet is reported as skipped.**

`build-info` on a reproducing build:

```
test_status:   { failed: 0, success: 6, queued: 0, ignored: 27, pending: 0 }
spec_timeout:  900000 ms          duration: 993 s
sessions:      status=error, 980 / 984 / 986 s
```

`failed: 0` is the tell. A thrown error always marks a test failing; nothing failed here. The sessions ran to ~985s against a 900s `spec_timeout` and were killed.

**Why they run that long.** The queue flush issues **one `cy.task` per queued event**, and each `cy.task` round-trip costs roughly **0.8s** on a remote terminal. Measured there, 6 tests per spec, N events per `afterEach`:

| events per `afterEach` | `cy.task` calls | session duration |
|---|---|---|
| 1 | 6 | 113s |
| 10 | 60 | 114s |
| 100 | 600 | **581s** |
| 1000 | 6000 | **killed at `spec_timeout`** |

A command-heavy test queues hundreds of events (`command:start` + `command:end` + `platform_details` per command, plus `log:changed`), so its `afterEach` alone runs for minutes. Load-dependent by construction: heavy tests exhaust the spec budget, light tests do not — which is exactly the reported 45-passed / 113-skipped shape rather than all-or-nothing.

**Why `1.32.8` is unaffected.** It dispatches via `cy.now('task', ...)`, which throws immediately on Cypress 14 with no IPC round-trip. `1.32.8` is fast because its dispatch does nothing — it also delivers no browser-side telemetry there. `v1.33.0` moved dispatch into the internal hooks and onto `cy.task`, which genuinely delivers but costs ~0.8s per event.

## Related Jira task/s
- SDK-7399

## Dependent PRs / release order
- Dependent PRs: **None** — CLI-only, no paired change in railsApp / realMobile / binary.
- [x] No cross-repo deploy order applies.

## Automation cases to add
- Cypress case asserting a command-heavy spec completes well inside `spec_timeout` with `expected_skipped_number: 0`. Existing `cypress_cli_and_dashboard.feature` rows already assert skipped counts and cover the success path.

## Code changes to check
- [x] Spread operator is not used.
- [x] Syntax supported by older Node — no `?.` / `??`.

## The change

**`plugin/index.js`** — new `test_observability_batch` task takes an array and fans out to the *same* IPC events. The four individual tasks stay registered for backward compatibility.

**`cypress/index.js`** — the flush builds one batch per drain instead of one `cy.task` per event, split at 512KB so each call stays under the ~1MB per-payload ceiling (also measured on the remote: 768KB passes, 1MB fails). Two thresholds, both from the same measurement: batches are closed at 512KB, and a single event above 768KB — the largest payload measured to send — is skipped with a log line. An event between the two still sends, alone in its own batch. Nothing is altered or truncated. `shouldSkipCommand` filters `test_observability_batch`, without which each batch dispatch would itself be captured as a command event and refill the queue.

Batching was verified **before** the code was written: the same 600 events sent as **one** `cy.task` call completed in **109s** versus **581s** as 600 calls — i.e. back to the ~110s baseline for that spec shape.

## Verification

**Fix, 3-spec repro** (suite modelled on the customer's shape: `cy.session` per test, per-test retry overrides, fixture chains in `before()`). Same suite and settings both arms; only the CLI dependency differs. Patched arm confirmed to ship a **fresh** dependency bundle, not a cached one, and the git dependency was verified to serve the branch head before running.

_Current head `456295d`_

| CLI | spec verdicts | tests run | session | duration | build |
|---|---|---|---|---|---|
| unpatched 1.36.9 | all 3 `passed_with_skipped` | 6 success / **27 ignored** | `error` — killed at `spec_timeout` | 1070s | [automate](https://automate.browserstack.com/dashboard/v2/builds/2014b2c2f2d6559fbdf0809f8dc51073aaeb7e09) |
| **this change** | **all 3 `passed`** | **33 success / 0 ignored** | **`done`** | **212s** | [automate](https://automate.browserstack.com/dashboard/v2/builds/35c1336ef17afe68b5412e9b5041dd3ded88c650) |

Video was enabled on both arms (`video: true`, confirmed in each build's `video_config`). The unpatched session is killed mid-run, so Cypress never finalises the recording; the patched session completes and the video is written — the "video will not load" complaint resolves with the same fix.

_Earlier run at `f64d61d`, before the threshold split — same outcome, which is what shows `3ec1263` changed nothing for normal-sized events_

| CLI | spec verdicts | tests run | duration | build |
|---|---|---|---|---|
| unpatched 1.36.9 | all 3 `passed_with_skipped` | 6 / **27 ignored** | 993s | [automate](https://automate.browserstack.com/dashboard/v2/builds/49c2da82ac2a63e68bfaa029444c02b030b6b527) |
| `f64d61d` | all 3 `passed` | 33 / 0 ignored | 213s | [automate](https://automate.browserstack.com/dashboard/v2/builds/a52ce26718031b8f0ae94450e28b54ed33b14b93) · [o11y](https://automation.browserstack.com/builds/gr21qnpjm0q8ylbmqrzbemhgckcgkmmaiouf4nlk) |

**Telemetry still delivers** — checked explicitly, because a passing spec cannot distinguish delivered from dropped. `test_observability_batch` accepts a mixed batch of all four event types, a 600-event batch, and a batch containing an unknown task name, all without failing (3/3).

## Release

**Version bump:**
- [ ] minor (backwards-compatible feature)
- [x] patch (bug fix or other small change)

**Release notes type:**
- [x] Bug Fix

**Release notes (customer-facing):**
- Fixed tests being incorrectly reported as skipped when Test Observability is enabled. Observability data is now sent in batches, so specs no longer run past their spec timeout on command-heavy tests.

**Release notes (internal):**
- `bin/testObservability/cypress/index.js` + `bin/testObservability/plugin/index.js`: the `beforeEach`/`afterEach` event-queue flush now sends one batched `cy.task` per drain (new `test_observability_batch` task) instead of one `cy.task` per event. Each round-trip costs ~0.8s on a remote terminal, so command-heavy tests were spending minutes in the hook and the spec was killed at `spec_timeout`, reporting unrun tests as skipped — the SDK-7399 symptom. Introduced in v1.33.0 when dispatch moved into these hooks and onto `cy.task`.
- Added `test/unit/bin/testObservability/batchFlush.js` covering the batch fan-out and the single-event dispatch threshold.
- Two distinct thresholds, both from the remote measurement (768KB succeeds in one `cy.task`, 1MB fails): batches are closed at 512KB, and only a single event above 768KB is skipped with a log line. An event between the two is dispatched alone in its own batch rather than dropped. Skipped events are logged rather than dropped silently.

## Checklist
- [x] Ready to review
- [ ] Has it been approved by a member of your team?
- [x] Verified end-to-end on BrowserStack infra (build links above)
- [x] Telemetry delivery verified separately from the pass/fail result
- [x] Required automation cases noted in description

## Reviewer notes

Environment gotchas found while verifying, worth knowing for any future o11y change:

- A CLI branch must resolve on **both** the local machine and the remote Windows terminal. A git-branch dependency works (repo is public); a local `file:` path or a `package_config_options.scripts.postinstall` pointing at a local path does not — `run_settings` ships verbatim to the remote (`capabilityHelper.js:131`), so the remote re-runs it and fails with `NPM_INSTALL_FAILED`.
- BrowserStack caches the dependency bundle by the generated `package.json` md5. Re-testing a changed patch under an unchanged dependency string silently reuses the **old** bundle (`"Skipping the upload of node_modules…"`). Add a bare `cacheBust` key to force a fresh upload.
- `browserstack-cypress build-info <buildId>` is the reliable way to see `test_status` / `spec_timeout` / session durations. The o11y ext API returned nulls for these builds and the session-logs URL returns a bot-challenge page.

Earlier commits on this branch explored two approaches that were verified and rejected: a reporter-side duplicate-event guard (no effect on a remote A/B), and switching dispatch to `cy.now` (stopped the skipping only by never delivering anything, since `cy.now('task')` throws on Cypress 14 in every context). Both are superseded by this change; history retained deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




